### PR TITLE
Allow to run ladecadanse with Docker Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ app/env.php
 .htaccess
 .git-ftp-ignore
 dploy.yaml
+composer-setup.php
+composer.phar

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ La majeur partie du site est composée d'un agenda permettant de naviguer dans l
 
 Une section d'administration permet de gérer les différentes contenus du site : utilisateurs, événements, lieux, organisateurs, etc.
 
-## Installation
+## Installation locale
 
 1. cloner la branche `master`
 1. créer le fichier de configuration du site en copiant le modèle `app/env_model.php` vers `app/env.php`
@@ -29,4 +29,12 @@ Une section d'administration permet de gérer les différentes contenus du site 
 1. afin d'avoir accès à l'administration, se connecter avec ce login *admin* et le mot de passe `MASTER_KEY` défini plus haut 
 1. (optionnel) installer [Pear Mail](https://pear.php.net/package/Mail/) pour que l'envoi d'emails fonctionne (les `require_once Mail.php;` dans le code)
 
+## Installation par Docker
+Lancer la commande suivante à la racine du projet:
+```
+docker compose up -d
+```
+Le site ladecadanse est déployé sur localhost:7777.
+
+## Dépendances
 Testé avec Apache 2.4, PHP 7.4, MariaDB 10/MySQL 5.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3'
+
+services:
+  db:
+    image: mariadb:10.3
+    container_name: ladecadanse_db
+    environment:
+      MYSQL_DATABASE: ladecadanse
+      MYSQL_ROOT_PASSWORD: dev
+      MYSQL_USER: dev
+      MYSQL_PASSWORD: dev
+    volumes:
+      - ${PWD}/app/ladecadanse.sql:/docker-entrypoint-initdb.d/ladecadanse.sql
+    ports:
+      - "127.0.0.1:9906:3306"
+    networks:
+      - ladecadanse_net
+  install-dep:
+    build:
+      dockerfile: ./docker/php/Dockerfile
+    container_name: ladecadanse_install_dep
+    command: ./install_dep.sh
+    volumes:
+      - ${PWD}:/var/www/html/
+  web:
+    build:
+      dockerfile: ./docker/php/Dockerfile
+    container_name: ladecadanse_php
+    depends_on:
+      db:
+        condition: service_started
+      install-dep:
+        condition: service_completed_successfully
+    volumes:
+      - ${PWD}:/var/www/html/
+      - ${PWD}/docker/apache/ladecadanse.conf:/etc/apache2/sites-enabled/000-default.conf
+      - ${PWD}/docker/env/env.php:/var/www/html/app/env.php
+    ports:
+      - "127.0.0.1:7777:80"
+    networks:
+      - ladecadanse_net
+    stdin_open: true
+    tty: true
+networks:
+  ladecadanse_net:

--- a/docker/apache/ladecadanse.conf
+++ b/docker/apache/ladecadanse.conf
@@ -1,0 +1,9 @@
+<VirtualHost *:80>
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+</VirtualHost>

--- a/docker/env/env.php
+++ b/docker/env/env.php
@@ -1,0 +1,55 @@
+<?php
+// make a copy of this file with name 'env.php'
+define("ENV", "dev");
+define("MODE_DEBUG", true);
+
+
+// full path of your ladecadanse application directory, for ex. "/home/michel/hosts/ladecadanse/"
+$rep_absolu = "/var/www/html/";
+
+// URL
+// main domain, for ex "http://localhost" or "http://ladecadanse.local";
+$url_domaine = "";
+// complete if your site is in a subdirectory, for ex with "ladecadanse", $url_site will be http://localhost/ladecadanse
+$url_site = $url_domaine."/";
+
+// database
+$param['dbhost'] = 'ladecadanse_db';
+$param['dbname'] = 'ladecadanse';
+$param['dbusername'] = 'dev';
+$param['dbpassword'] = 'dev';
+
+// SMTP credentials
+// $glo_email_host = "mail.darksite.ch"; // prod
+// $glo_email_username = "info@ladecadanse.ch"; // prod
+$glo_email_host = "";
+$glo_email_username = "";
+$glo_email_password = "";
+
+// $glo_email_admin = "michel@ladecadanse.ch"; // prod
+// $glo_email_info = "info@ladecadanse.ch"; // prod
+// $glo_email_support = "info@ladecadanse.ch"; // prod
+$glo_email_admin = "";
+$glo_email_info = "";
+$glo_email_support = "";
+
+define("MAIL_DOMAIN", '');
+
+define("MASTER_KEY", ''); // backdoor : allows to login with any user
+
+define("GOOGLE_API_KEY", ''); // use Google Maps library to display maps of venues
+
+define("GOOGLE_RECAPTCHA_API_KEY_CLIENT", ''); // for (public) "Proposer un événement form"
+define("GOOGLE_RECAPTCHA_API_KEY_SERVER", '');
+
+define("GOOGLE_ANALYTICS_ID", ''); // 1st analytics tool (enabled only in prod)
+define("GOOGLE_ANALYTICS_ENABLED", false);
+
+define("MATOMO_ENABLED", false); // 2nd analytics tool (enabled only in prod)
+
+define("PREVIEW", true);
+
+// closable banner in homepage for announcements
+define("HOME_TMP_BANNER_ENABLED", false);
+define("HOME_TMP_BANNER_TITLE", "");
+define("HOME_TMP_BANNER_CONTENT", "");

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:7.4-apache
+RUN apt-get update && apt-get install -y zlib1g-dev libpng-dev zip
+RUN docker-php-ext-install mysqli && \
+    docker-php-ext-install gd

--- a/install_dep.sh
+++ b/install_dep.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php composer-setup.php install
+php composer.phar update


### PR DESCRIPTION
Run the following command at the root of the project:
```
docker compose up -d
```
The ladecadanse site is deployed on localhost:7777

Tested on macOS 13.1 with Docker Desktop 4.16.1