### PR TITLE
Set the default timezone in config.php instead of Apache - closes #67

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ Ces instructions vous permettront de mettre en place une copie du projet sur vot
         ```sql
         INSERT INTO `personne` (`idPersonne`, `pseudo`, `mot_de_passe`, `cookie`, `groupe`, `statut`, `affiliation`, `region`, `email`,  `signature`, `avec_affiliation`, `gds`, `actif`, `dateAjout`, `date_derniere_modif`) VALUES (NULL, 'admin', '$2y$10$34Z0QxaycAgPFQGtiVzPbeoZFN1kwLEdWDEBI1kEOJGK4A3xRJtMa', '', '1', 'actif', '', 'ge', '', 'pseudo', 'non', '', '1', '0000-00-00 00:00:00.000000', '0000-00-00 00:00:00.000000');
         ```
-1. dans un fichier de configuration Apache (`.htaccess` ou autre) définir le décalage horaire par défaut PHP, par ex. :
-    ```ini
-    php_value date.timezone 'Europe/Zurich'
-    ```
 1. copier `app/env_model.php` vers `app/env.php` et y saisir les valeurs de votre environnement (davantage d'explications et exemples se trouvent dans le fichier lui même), avec au minimum les informations de connexion à la base de données
 
 ### Par Docker

--- a/app/config.php
+++ b/app/config.php
@@ -40,6 +40,7 @@ $mimes_documents_acceptes = array("image/jpeg", "image/pjpeg", "image/gif", "ima
     "application/zip", "multipart/x-zip", "multipart/x-gzip", "application/x-tar");
 
 
+date_default_timezone_set('Europe/Zurich');
 $glo_auj = date("Y-m-d");
 $auj = date("Y-m-d");
 $glo_auj_6h = date("Y-m-d", time() - 14400); // 4h


### PR DESCRIPTION
Adds a date_default_timezone_set function (set to 'Europe/Zurich') to app/config.php, ending the need to do this in the Apache config (.htaccess or other). This also allows to use the built-in php server, which is useful for testing purposes (per @gagarine)