### PR TITLE
#116 lieu-salle-edit.php : organize main parts, clean code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ladecadanse_db_data:/var/lib/mysql
       - ${PWD}/resources/ladecadanse.sql:/docker-entrypoint-initdb.d/001_ladecadanse.sql
       - ${PWD}/docker/env/create-admin.sql:/docker-entrypoint-initdb.d/002_create-admin.sql
+      - ${PWD}/docker/env/create-lieux.sql:/docker-entrypoint-initdb.d/003_create-lieux.sql
     ports:
       - "127.0.0.1:${DB_PORT:-9906}:3306"
     networks:

--- a/docker/env/create-lieux.sql
+++ b/docker/env/create-lieux.sql
@@ -1,0 +1,5 @@
+-- Fixtures pour les tests Selenium
+INSERT INTO `lieu` (`idLieu`, `idpersonne`, `statut`, `nom`, `determinant`, `adresse`, `quartier`, `localite_id`, `region`, `lat`, `lng`, `categorie`, `horaire_general`, `photo1`, `photo2`, `logo`, `URL`, `actif`, `dateAjout`, `date_derniere_modif`) VALUES
+(999, 1, 'actif', 'Lieu Test Selenium', 'au', 'Rue du Test 42', '', 86, 'ge', 0, 0, 'salle', 'Lun-Ven 9h-18h', '', '', '', 'https://test.local', 1, NOW(), NOW());
+
+

--- a/librairies/SalleEdition.php
+++ b/librairies/SalleEdition.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Ladecadanse;
+
+use Ladecadanse\Utils\Validateur;
+use Ladecadanse\Utils\DbConnectorPdo;
+
+class SalleEdition extends Edition
+{
+    private DbConnectorPdo $pdo;
+    private int $idPersonne;
+    private ?int $idSalle = null;
+
+    public function __construct()
+    {
+        $champs = [
+            'idLieu' => '',
+            'nom' => '',
+            'emplacement' => '',
+        ];
+
+        parent::__construct('salle', $champs, []);
+        $this->pdo = DbConnectorPdo::getInstance();
+        $this->verif = new Validateur();
+    }
+
+    public function setIdPersonne(int $idPersonne): void
+    {
+        $this->idPersonne = $idPersonne;
+    }
+
+    public function setIdSalle(?int $idSalle): void
+    {
+        $this->idSalle = $idSalle;
+    }
+
+    #[\Override]
+    public function traitement(array $post, array $files): bool
+    {
+        foreach ($this->valeurs as $nom => $val) {
+            if (isset($post[$nom])) {
+                $this->valeurs[$nom] = $post[$nom];
+            }
+        }
+
+        if (!$this->verification()) {
+            return false;
+        }
+
+        return $this->enregistrer();
+    }
+
+    #[\Override]
+    public function enregistrer(): bool
+    {
+        return match ($this->action) {
+            'insert' => $this->insert($this->idPersonne) !== null,
+            'update' => $this->update($this->idSalle),
+            default => false,
+        };
+    }
+
+    #[\Override]
+    public function verification(): bool
+    {
+        $this->verif = new Validateur();
+
+        $this->verif->valider($this->valeurs['idLieu'], "idLieu", "texte", 1, 60, 1);
+        $this->verif->valider($this->valeurs['nom'], "nom", "texte", 2, 100, 1);
+        $this->verif->valider($this->valeurs['emplacement'], "emplacement", "texte", 2, 100, 0);
+
+        if ($this->verif->nbErreurs() === 0) {
+            $stmt = $this->pdo->prepare("SELECT idLieu FROM lieu WHERE idLieu = :idLieu");
+            $stmt->execute([':idLieu' => $this->valeurs['idLieu']]);
+            if (!$stmt->fetch()) {
+                $this->verif->setErreur("idLieu", "Ce lieu n'est pas dans la liste");
+            }
+        }
+
+        $this->erreurs = array_merge($this->erreurs, $this->verif->getErreurs());
+
+        return $this->verif->nbErreurs() === 0;
+    }
+
+    #[\Override]
+    public function loadValeurs(int $id): void
+    {
+        $stmt = $this->pdo->prepare("SELECT * FROM salle WHERE idSalle = :idSalle");
+        $stmt->execute([':idSalle' => $id]);
+
+        if ($row = $stmt->fetch()) {
+            foreach ($row as $key => $value) {
+                if (array_key_exists($key, $this->valeurs)) {
+                    $this->valeurs[$key] = $value;
+                }
+            }
+            $this->id = $id;
+        }
+    }
+
+    public function insert(int $idPersonne): ?int
+    {
+        $now = date("Y-m-d H:i:s");
+
+        $stmt = $this->pdo->prepare("
+            INSERT INTO salle (idLieu, nom, emplacement, dateAjout, date_derniere_modif, idPersonne)
+            VALUES (:idLieu, :nom, :emplacement, :dateAjout, :dateModif, :idPersonne)
+        ");
+
+        $result = $stmt->execute([
+            ':idLieu' => $this->valeurs['idLieu'],
+            ':nom' => $this->valeurs['nom'],
+            ':emplacement' => $this->valeurs['emplacement'],
+            ':dateAjout' => $now,
+            ':dateModif' => $now,
+            ':idPersonne' => $idPersonne,
+        ]);
+
+        if ($result) {
+            $this->id = (int)$this->pdo->lastInsertId();
+            $this->message = "Salle <em>" . sanitizeForHtml($this->valeurs['nom']) . "</em> ajoutée";
+            return $this->id;
+        }
+
+        return null;
+    }
+
+    public function update(int $idSalle): bool
+    {
+        $now = date("Y-m-d H:i:s");
+
+        $stmt = $this->pdo->prepare("
+            UPDATE salle 
+            SET nom = :nom, emplacement = :emplacement, date_derniere_modif = :dateModif
+            WHERE idSalle = :idSalle
+        ");
+
+        $result = $stmt->execute([
+            ':nom' => $this->valeurs['nom'],
+            ':emplacement' => $this->valeurs['emplacement'],
+            ':dateModif' => $now,
+            ':idSalle' => $idSalle,
+        ]);
+
+        if ($result) {
+            $this->message = "Salle modifiée";
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getLieux(): array
+    {
+        $stmt = $this->pdo->query("SELECT idLieu, nom FROM lieu ORDER BY nom");
+        return $stmt->fetchAll();
+    }
+
+    public function getValidationError(string $field): string
+    {
+        return $this->verif->getErreur($field);
+    }
+
+    public function hasErrors(): bool
+    {
+        return $this->verif->nbErreurs() > 0;
+    }
+
+    public function getErrorCount(): int
+    {
+        return $this->verif->nbErreurs();
+    }
+}

--- a/lieu-salle-edit.php
+++ b/lieu-salle-edit.php
@@ -2,37 +2,64 @@
 
 require_once("app/bootstrap.php");
 
+use Ladecadanse\Security\SecurityToken;
+use Ladecadanse\SalleEdition;
 use Ladecadanse\Utils\Validateur;
 use Ladecadanse\HtmlShrink;
+use Ladecadanse\UserLevel;
 
-if (!$videur->checkGroup(8))
-{
+if (!$videur->checkGroup(UserLevel::ACTOR)) {
     header($_SERVER["SERVER_PROTOCOL"] . " 403 Forbidden");
-	header("Location: /user-login.php");
+    header("Location: /user-login.php");
     die();
 }
 
-/*
-* action choisie, idL et idP si édition
-*/
 $tab_actions = ["ajouter", "insert", "editer", "update"];
-$get['action'] = "ajouter";
-if (isset($_GET['action']))
-{
-	$get['action'] = Validateur::validateUrlQueryValue($_GET['action'], "enum", 0, $tab_actions);
+$get = [
+    'action' => Validateur::validateUrlQueryValue($_GET['action'] ?? 'ajouter', "enum", 'ajouter', $tab_actions),
+    'idS' => (int)($_GET['idS'] ?? 0),
+    'idL' => (int)($_GET['idL'] ?? 0),
+];
+
+$isAddMode = in_array($get['action'], ['ajouter', 'insert']);
+$isEditMode = in_array($get['action'], ['editer', 'update']);
+
+if ($isEditMode && $_SESSION['Sgroupe'] > UserLevel::ADMIN) {
+    HtmlShrink::msgErreur("Vous n'avez pas les droits pour éditer cette salle");
+    exit;
 }
 
-$get['idS'] = 0;
-if (isset($_GET['idS']))
-{
-	$get['idS'] = (int)$_GET['idS'];
+$salleForm = new SalleEdition();
+$salleForm->setAction($get['action']);
+$salleForm->setIdPersonne($_SESSION['SidPersonne']);
+$salleForm->setIdSalle($get['idS'] ?: null);
+
+if ($get['action'] === 'editer' && $get['idS'] > 0) {
+    $salleForm->loadValeurs($get['idS']);
+} elseif ($get['idL'] > 0) {
+    $salleForm->setValeur('idLieu', $get['idL']);
 }
 
-$get['idL'] = 0;
-if (isset($_GET['idL']))
-{
-	$get['idL'] = (int)$_GET['idL'];
+if (($_POST['formulaire'] ?? '') === 'ok') {
+    if (!SecurityToken::check($_POST['token'] ?? '', $_SESSION['token'] ?? '')) {
+        echo "Le système de sécurité du site n'a pu authentifier votre action. Veuillez réafficher ce formulaire et réessayer";
+        exit;
+    }
+
+    if ($salleForm->traitement($_POST, [])) {
+        $_SESSION['lieu_flash_msg'] = $salleForm->getMessage();
+        header("Location: /lieu/lieu.php?idL=" . (int)$salleForm->getValeur('idLieu'));
+        die();
+    }
+
+    if (!$salleForm->hasErrors()) {
+        HtmlShrink::msgErreur("La requête a échoué");
+    }
 }
+
+$titre_form = $isEditMode ? "Modifier une salle" : "Ajouter une salle à un lieu";
+$act = $isEditMode ? "update&idS={$get['idS']}" : "insert";
+$lieux = $salleForm->getLieux();
 
 $page_titre = "ajouter/modifier une salle";
 $extra_css = ["formulaires"];
@@ -41,273 +68,65 @@ include("_header.inc.php");
 
 <main id="contenu" class="colonne">
 
-<?php
+<header id="entete_contenu">
+    <h1><?= sanitizeForHtml($titre_form) ?></h1>
+    <div class="spacer"></div>
+</header>
 
-/* VERIFICATION POUR MODIFICATION
-* Si ce n'est pas un ajout et que la personne, n'est pas l'auteur de la desc ni admin -> exit
-*/
-if ($get['action'] != "ajouter" && $get['action'] != "insert")
-{
-	if ($_SESSION['Sgroupe'] > 6)
-	{
-		HtmlShrink::msgErreur("Vous n'avez pas les droits pour éditer cette salle");
-		exit;
-	}
-}
+<?php if ($salleForm->hasErrors()): ?>
+    <?php HtmlShrink::msgErreur("Il y a " . $salleForm->getErrorCount() . " erreur(s)."); ?>
+<?php endif; ?>
 
-
-/*
-* TRAITEMENT DU FORMULAIRE (EDITION OU AJOUT)
-*/
-$verif = new Validateur();
-
-$champs = ["idLieu" => '', "nom" => '', "emplacement" => ''];
-
-$action_terminee = false;
-
-if (isset($_POST['formulaire']) && $_POST['formulaire'] === 'ok' )
-{
-	/*
-	 * Copie des champs envoyê³ par POST
-	 */
-	foreach ($champs as $c => $v)
-	{
-		$champs[$c] = $_POST[$c];
-	}
-
-	$verif->valider($champs['idLieu'], "idLieu", "texte", 1, 60, 1);
-	$verif->valider($champs['nom'], "nom", "texte", 2, 100, 1);
-	$verif->valider($champs['emplacement'], "emplacement", "texte", 2, 100, 0);
-
-	/*
-	 * Nom du lieu obligatoire et vê³©f si le lieu dê´©gné¡°ar idL existe bien dans la table lieu
-	 */
-	if ($connector->getNumRows($connector->query("SELECT idLieu FROM lieu WHERE idLieu=".$connector->sanitize($champs['idLieu']))) < 1)
-	{
-			$verif->setErreur("idLieu", "Ce lieu n'est pas dans la liste");
-	}
-
-	/*
-	 * Pas d'erreur, donc ajout ou update executés
-	 */
-	if ($verif->nbErreurs() === 0)
-	{
-		//creation/nettoyage des valeurs à insérer dans la table
-		$pers = $_SESSION['SidPersonne'];
-
-		/*
-		* Insertion dans la base : INSERT
-		*/
-		if ($get['action'] == 'insert')
-		{
-
-			$sql_insert_attributs = "";
-			$sql_insert_valeurs = "";
-
-			foreach ($champs as $c => $v)
-			{
-				$sql_insert_attributs .= $c.", ";
-				$sql_insert_valeurs .= "'".$connector->sanitize($v)."', ";
-			}
-
-			$sql_insert_attributs .= "dateAjout, date_derniere_modif, idPersonne";
-			$sql_insert_valeurs .= "'".date("Y-m-d H:i:s")."', '".date("Y-m-d H:i:s")."', ".$pers;
-
-			$sql_insert = "INSERT INTO salle (".$sql_insert_attributs.") VALUES (".$sql_insert_valeurs.")";
-
-			//TEST
-			//echo "<p>".$sql_insert."</p>";
-			//
-
-			//message résultat et réinit
-			if ($connector->query($sql_insert))
-			{
-
-				HtmlShrink::msgOk("Salle <em>".sanitizeForHtml($champs['nom'])."</em> ajoutée");
-				$action_terminee = true;
-			}
-			else
-			{
-				HtmlShrink::msgErreur("La requête INSERT a échoué");
-			}
-
-		/*
-		* Insertion dans la base : UPDATE
-		*/
-		}
-		elseif ($get['action'] == 'update')
-		{
-
-			$champs['date_derniere_modif'] = date("Y-m-d H:i:s");
-
-			$sql_update = "UPDATE salle SET
-			nom='".$connector->sanitize($champs['nom'])."', emplacement='".$connector->sanitize($champs['emplacement'])."', date_derniere_modif='".$champs['date_derniere_modif']."'
-			WHERE idSalle=".(int)$get['idS'];
-
-			$req_update = $connector->query($sql_update);
-
-			//message résultat et réinit de l'action
-			if ($req_update)
-			{
-
-				HtmlShrink::msgOk('Salle du <a href="/lieu/lieu.php?idL='.(int)$champs['idLieu'].'">lieu</a> modifiée');
-
-				$get['action'] = 'editer';
-				$action_terminee = true;
-			}
-			else
-			{
-				HtmlShrink::msgErreur("La requête UPDATE a échoué");
-			}
-
-		} //if action
-
-
-	} // if erreurs == 0
-
-
-} // if POST != ""
-
-if (!$action_terminee)
-{
-
-echo '<header id="entete_contenu">';
-
-
-/*
- * PREPARATION DES URLS SELON LES ACTIONS,
- * update et idB en cas d'édition, insert pour ajout
- */
-if ($get['action'] == 'editer' || $get['action'] == 'update')
-{
-	$act = "update&idS=".(int)$get['idS'];
-	$req_lieu = $connector->query("SELECT * FROM salle WHERE idSalle=".(int)$get['idS']);
- 	$detailsLieu = $connector->fetchArray($req_lieu);
-    echo '<h1>Modifier</h1>';
-}
-else
-{
-    $act = "insert";
-	echo "<h1>Ajouter une salle à un lieu</h1>";
-}
-
-/*
-* POUR EDITER UNE DESCRIPTION, ALLER CHERCHER SES VALEURS DANS LA BASE
-* Accessible par son auteur ou un admin
-* Récupération des valeurs de la table et remplissage des champs pour le formulaire
-* Affichage d'un menu d'actions pour l'admin
-*/
-if ($get['action'] == 'editer' && isset($get['idS']))
-{
-
-	$sql = "SELECT * FROM salle WHERE idSalle=".(int)$get['idS'];
-	//echo $sql;
-	$req_desc = $connector->query($sql);
-
-	if ($tabDesc = $connector->fetchArray($req_desc))
-	{
-			foreach($tabDesc as $c => $v)
-			{
-				$champs[$c] = $v;
-			}
-	}
-} // if GET action
-
-echo '<div class="spacer"></div></header>';
-
-
-
-if ($verif->nbErreurs() > 0)
-{
-	HtmlShrink::msgErreur("Il y a ".$verif->nbErreurs()." erreur(s).");
-	//print_r($verif->getErreurs());
-}
-
-
-?>
-
-
-
-<!-- FORMULAIRE POUR UNE DESCRIPTION -->
-<form method="post" id="ajouter_editer" enctype="multipart/form-data" class="js-submit-freeze-wait" action="<?php echo basename(__FILE__)."?action=".$act; ?>">
+<form method="post" id="ajouter_editer" enctype="multipart/form-data" class="js-submit-freeze-wait" action="<?= basename(__FILE__) ?>?action=<?= $act ?>">
 
 <p>* indique un champ obligatoire</p>
 
 <fieldset>
 <legend>Salle</legend>
-<!-- Select liste des lieux -->
 
 <p>
-<label for="idLieu">Lieu* :</label>
-<?php
-if (($get['action'] != 'editer' || $get['action'] != 'update') && !empty($get['idL']))
-{
-	$champs['idLieu'] = $get['idL'];
-
-}
-	echo "<select name=\"idLieu\" id=\"idLieu\" class=\"js-select2-options-with-style\" data-placeholder=\"\">
-	<option value=\"\"></option>";
-    $req_lieux = $connector->query("SELECT idLieu, nom FROM lieu ORDER BY nom");
-
-	while ($lieuTrouve = $connector->fetchArray($req_lieux))
-	{
-	    echo "<option";
-		if ($lieuTrouve['idLieu'] == $champs['idLieu'])
-		{
-		  	echo " selected=\"selected\"";
-		}
-		echo " value=\"" . $lieuTrouve['idLieu'] . "\">" . sanitizeForHtml($lieuTrouve['nom']) . "</option>";
-    }
-
-?>
-</select>
-<?php
-echo $verif->getErreur('idLieu');
-echo $verif->getErreur('doublon');
-echo $verif->getErreur('nom');
-?>
-</p>
-
-
-<p>
-<label for="nom">Nom* :</label>
-<input name="nom" id="nom" type="text" size="30" title="nom" value="<?php echo sanitizeForHtml($champs['nom']) ?>" />
-<?php echo $verif->getErreur("nom"); ?>
+    <label for="idLieu">Lieu* :</label>
+    <select name="idLieu" id="idLieu" class="js-select2-options-with-style" data-placeholder="">
+        <option value=""></option>
+        <?php foreach ($lieux as $lieu): ?>
+            <option value="<?= $lieu['idLieu'] ?>"<?= $lieu['idLieu'] == $salleForm->getValeur('idLieu') ? ' selected' : '' ?>>
+                <?= sanitizeForHtml($lieu['nom']) ?>
+            </option>
+        <?php endforeach; ?>
+    </select>
+    <?= $salleForm->getValidationError('idLieu') ?>
 </p>
 
 <p>
-<label for="emplacement">Emplacement :</label>
-<input name="emplacement" id="emplacement" type="text" size="30" title="emplacement" value="<?php echo sanitizeForHtml($champs['emplacement']) ?>" />
-<?php echo $verif->getErreur("emplacement"); ?>
+    <label for="nom">Nom* :</label>
+    <input name="nom" id="nom" type="text" size="30" value="<?= sanitizeForHtml($salleForm->getValeur('nom')) ?>">
+    <?= $salleForm->getValidationError('nom') ?>
 </p>
 
+<p>
+    <label for="emplacement">Emplacement :</label>
+    <input name="emplacement" id="emplacement" type="text" size="30" value="<?= sanitizeForHtml($salleForm->getValeur('emplacement')) ?>">
+    <?= $salleForm->getValidationError('emplacement') ?>
+</p>
 
 </fieldset>
 
-    <p class="piedForm">
-    <input type="hidden" name="formulaire" value="ok" />
-    <input type="submit" value="Enregistrer" class="submit submit-big" />
-    </p>
-
+<p class="piedForm">
+    <input type="hidden" name="formulaire" value="ok">
+    <input type="hidden" name="token" value="<?= SecurityToken::getToken() ?>">
+    <input type="submit" value="Enregistrer" class="submit submit-big">
+</p>
 
 </form>
 
-<?php
-} // if action_terminee
-?>
-
 </main>
-<!-- fin contenu  -->
 
 <div id="colonne_gauche" class="colonne">
-
 <?php include("event/_navigation_calendrier.inc.php"); ?>
 </div>
-<!-- Fin Colonne gauche -->
 
 <div id="colonne_droite" class="colonne">
 </div>
 
 <?php
 include("_footer.inc.php");
-?>

--- a/tests/ladecadanse.side
+++ b/tests/ladecadanse.side
@@ -7257,6 +7257,166 @@
       ],
       "value": ""
     }]
+  }, {
+    "id": "a1b2c3d4-5678-90ab-cdef-lieu-salle-01",
+    "name": "admin lieu-salle add (vars r)",
+    "commands": [{
+      "id": "cmd-salle-000",
+      "comment": "Clear all cookies for fresh session",
+      "command": "executeScript",
+      "target": "document.cookie.split(';').forEach(c => document.cookie = c.trim().split('=')[0] + '=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/');",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "cmd-salle-000b",
+      "comment": "Navigate to logout page",
+      "command": "open",
+      "target": "/user-logout.php",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "cmd-salle-000c",
+      "comment": "Wait for logout to complete",
+      "command": "pause",
+      "target": "500",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "cmd-salle-001",
+      "comment": "Open homepage",
+      "command": "open",
+      "target": "/",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "cmd-salle-002",
+      "comment": "Set window size",
+      "command": "setWindowSize",
+      "target": "1440x900",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "cmd-salle-003",
+      "comment": "Click login link",
+      "command": "click",
+      "target": "linkText=Connexion",
+      "targets": [
+        ["linkText=Connexion", "linkText"],
+        ["xpath=//a[contains(@href, '/user-login.php')]", "xpath:href"]
+      ],
+      "value": ""
+    }, {
+      "id": "cmd-salle-004",
+      "comment": "Enter admin username",
+      "command": "type",
+      "target": "id=pseudo",
+      "targets": [
+        ["id=pseudo", "id"],
+        ["name=pseudo", "name"]
+      ],
+      "value": "admin"
+    }, {
+      "id": "cmd-salle-005",
+      "comment": "Enter admin password",
+      "command": "type",
+      "target": "id=motdepasse",
+      "targets": [
+        ["id=motdepasse", "id"],
+        ["name=motdepasse", "name"]
+      ],
+      "value": "admin_dev"
+    }, {
+      "id": "cmd-salle-006",
+      "comment": "Submit login form",
+      "command": "click",
+      "target": "css=.submit-big",
+      "targets": [
+        ["css=.submit-big", "css:finder"],
+        ["xpath=//input[@value='Connexion']", "xpath:attributes"]
+      ],
+      "value": ""
+    }, {
+      "id": "cmd-salle-007",
+      "comment": "Wait for login",
+      "command": "pause",
+      "target": "1000",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "cmd-salle-008",
+      "comment": "Go directly to lieu-salle-edit page",
+      "command": "open",
+      "target": "/lieu-salle-edit.php",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "cmd-salle-009",
+      "comment": "Verify form is displayed",
+      "command": "assertElementPresent",
+      "target": "id=idLieu",
+      "targets": [
+        ["id=idLieu", "id"],
+        ["name=idLieu", "name"]
+      ],
+      "value": ""
+    }, {
+      "id": "cmd-salle-009b",
+      "comment": "Select lieu from dropdown (select2)",
+      "command": "select",
+      "target": "id=idLieu",
+      "targets": [
+        ["id=idLieu", "id"],
+        ["name=idLieu", "name"]
+      ],
+      "value": "value=999"
+    }, {
+      "id": "cmd-salle-011",
+      "comment": "Fill salle name",
+      "command": "type",
+      "target": "id=nom",
+      "targets": [
+        ["id=nom", "id"],
+        ["name=nom", "name"]
+      ],
+      "value": "Salle Test Selenium"
+    }, {
+      "id": "cmd-salle-012",
+      "comment": "Fill salle location",
+      "command": "type",
+      "target": "id=emplacement",
+      "targets": [
+        ["id=emplacement", "id"],
+        ["name=emplacement", "name"]
+      ],
+      "value": "1er étage"
+    }, {
+      "id": "cmd-salle-013",
+      "comment": "Submit form",
+      "command": "click",
+      "target": "css=.submit-big",
+      "targets": [
+        ["css=.submit-big", "css:finder"],
+        ["xpath=//input[@value='Enregistrer']", "xpath:attributes"]
+      ],
+      "value": ""
+    }, {
+      "id": "cmd-salle-014",
+      "comment": "Wait for redirect",
+      "command": "pause",
+      "target": "1000",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "cmd-salle-015",
+      "comment": "Verify success - salle appears in lieu page",
+      "command": "assertElementPresent",
+      "target": "xpath=//ul[@class='salles']//li[contains(text(), 'Salle Test Selenium')]",
+      "targets": [
+        ["xpath=//ul[@class='salles']//li[contains(text(), 'Salle Test Selenium')]", "xpath:innerText"],
+        ["css=.salles li", "css:finder"]
+      ],
+      "value": ""
+    }]
   }],
   "suites": [{
     "id": "e598238f-e9bc-40f6-9876-6274e4bf1e3f",
@@ -7278,7 +7438,7 @@
     "persistSession": false,
     "parallel": false,
     "timeout": 300,
-    "tests": ["fa4a12b8-1f55-4435-8fe1-3fe8294be63a", "d5d4f0bd-52d5-4cd9-8fd2-b38ee992812d", "5c790b97-c4b1-4056-a004-daa889c1a3ee", "2422f54c-2560-4fa2-ad65-b10fe0deba9e", "1e32da4f-4dcb-4195-8dee-81a2afc12a3f", "b4c14c81-4533-4742-8d96-526b91077359", "1e0fa7b9-f784-4860-a139-b7be9b393fc0", "8f01a9a0-9f4c-4f52-825e-a54eba6fcb27", "92d58e15-7bbd-49aa-8440-5c14b4554622", "7f6cb209-b243-4a0e-889f-097dd12be52d", "9c8c7ca0-0ac3-496e-b84b-bfedbc01230b", "602346d1-62ed-43a5-9bfd-b78a52eaaa59", "816a221b-9428-4767-9d1b-cf51dc2f8fb4", "1b3cabfb-9a16-44ae-b21b-2356228e88f1"]
+    "tests": ["fa4a12b8-1f55-4435-8fe1-3fe8294be63a", "d5d4f0bd-52d5-4cd9-8fd2-b38ee992812d", "5c790b97-c4b1-4056-a004-daa889c1a3ee", "2422f54c-2560-4fa2-ad65-b10fe0deba9e", "1e32da4f-4dcb-4195-8dee-81a2afc12a3f", "b4c14c81-4533-4742-8d96-526b91077359", "1e0fa7b9-f784-4860-a139-b7be9b393fc0", "8f01a9a0-9f4c-4f52-825e-a54eba6fcb27", "92d58e15-7bbd-49aa-8440-5c14b4554622", "7f6cb209-b243-4a0e-889f-097dd12be52d", "9c8c7ca0-0ac3-496e-b84b-bfedbc01230b", "602346d1-62ed-43a5-9bfd-b78a52eaaa59", "816a221b-9428-4767-9d1b-cf51dc2f8fb4", "1b3cabfb-9a16-44ae-b21b-2356228e88f1", "a1b2c3d4-5678-90ab-cdef-lieu-salle-01"]
   }],
   "urls": ["https://ladecadanse.darksite.ch/", "http://ladecadanse.local/", "https://ladecadanse.local/"],
   "plugins": []


### PR DESCRIPTION
## Changes

### New class `SalleEdition` (`librairies/SalleEdition.php`)
- Extends `Edition` following the existing pattern (`LieuEdition`, `OrganisateurEdition`)
- Handles validation, loading, and saving of salle data
- Uses PDO with prepared statements

### Refactored controller (`lieu-salle-edit.php`)
- Separated business logic from presentation
- Uses `UserLevel` constants instead of magic numbers
- Cleaner form submission handling

### Test fixtures
- Added `docker/env/create-lieux.sql` for Selenium test data
- Added Selenium test for salle creation flow