### PR TITLE
feat(event): add export to Google, Outlook, Microsoft 365, Yahoo cale…

### DIFF
--- a/event/_calendar_export.inc.php
+++ b/event/_calendar_export.inc.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Calendar export dropdown menu.
+ *
+ * Required variable: $calLinks (from EvenementCalendarRenderer::getLinks())
+ * Optional variable: $calExportCompact (bool) - icon-only trigger with tooltip (default: false, shows full label)
+ * Optional variable: $calExportId (string) - unique suffix for menu id (required when multiple on same page)
+ */
+
+$menuId = 'calendar-export-menu' . (!empty($calExportId) ? '-' . $calExportId : '');
+?>
+<li class="calendar-export-wrapper">
+    <?php if (!empty($calExportCompact)) : ?>
+        <a href="#" class="ical dropdown" data-target="<?= $menuId ?>" title="Ajouter à un agenda"><i class="fa fa-calendar-plus-o fa-lg"></i></a>
+    <?php else : ?>
+        <a href="#" class="dropdown" data-target="<?= $menuId ?>"><i class="fa fa-calendar-plus-o fa-lg"></i>&nbsp;Ajouter à un agenda&nbsp;<i class="fa fa-caret-down" aria-hidden="true"></i></a>
+    <?php endif; ?>
+    <ul id="<?= $menuId ?>" class="calendar-export-menu" style="display:none;">
+        <li><a href="<?= $calLinks['google'] ?>" target="_blank" rel="noopener"><i class="fa fa-google fa-fw"></i>&nbsp;Google Calendar</a></li>
+        <li><a href="<?= $calLinks['outlook'] ?>" target="_blank" rel="noopener"><i class="fa fa-windows fa-fw"></i>&nbsp;Outlook.com</a></li>
+        <li><a href="<?= $calLinks['office365'] ?>" target="_blank" rel="noopener"><i class="fa fa-building-o fa-fw"></i>&nbsp;Microsoft 365</a></li>
+        <li><a href="<?= $calLinks['yahoo'] ?>" target="_blank" rel="noopener"><i class="fa fa-yahoo fa-fw"></i>&nbsp;Yahoo</a></li>
+        <li><a href="<?= $calLinks['ical'] ?>"><i class="fa fa-apple fa-fw"></i>&nbsp;iCal / Apple</a></li>
+    </ul>
+</li>

--- a/event/evenement.php
+++ b/event/evenement.php
@@ -198,7 +198,10 @@ include("../_header.inc.php");
                 <li><a href="/event/copy.php?idE=<?= (int) $get['idE'] ?>"><?= $iconeCopier ?>&nbsp;Copier vers d'autres dates</a></li>
                 <li><a href="/evenement-edit.php?action=editer&amp;idE=<?= (int) $get['idE'] ?>"><?= $iconeEditer ?>&nbsp;Modifier</a></li>
             <?php endif; ?>
-                <li><a href="/event/to-ics.php?idE=<?= (int) $get['idE'] ?>" title="Exporter au format iCalendar dans votre agenda"><i class="fa fa-calendar-plus-o fa-lg"></i>&nbsp;iCal</a></li>
+                <?php
+                $calLinks = (new Ladecadanse\EvenementCalendarRenderer($tab_even, $site_full_url))->getLinks();
+                include("_calendar_export.inc.php");
+                ?>
         </ul>
     </nav>
 

--- a/index.php
+++ b/index.php
@@ -277,7 +277,13 @@ include("_header.inc.php");
 
                                 <ul class="menu_action">
                                     <li><a href="/event/send.php?action=report&idE=<?= (int) $tab_even['e_idEvenement']; ?>" class="signaler" title="Signaler une erreur"><i class="fa fa-flag-o fa-lg"></i></a></li>
-                                    <li><a href="/event/to-ics.php?idE=<?= (int) $tab_even['e_idEvenement']; ?>" class="ical" title="Exporter au format iCalendar dans votre agenda"><i class="fa fa-calendar-plus-o fa-lg"></i></a></li>
+                                    <?php
+                                    $calLinks = (new Ladecadanse\EvenementCalendarRenderer($tab_even, $site_full_url))->getLinks();
+                                    $calExportCompact = true;
+                                    $calExportId = (int) $tab_even['e_idEvenement'];
+                                    include("event/_calendar_export.inc.php");
+                                    unset($calExportCompact, $calExportId);
+                                    ?>
                                 </ul>
 
                                 <?php if ($authorization->isPersonneAllowedToEditEvenement($_SESSION, $tab_even)) : ?>

--- a/librairies/EvenementCalendarRenderer.php
+++ b/librairies/EvenementCalendarRenderer.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * @package ladecadanse
+ * @copyright  Copyright (c) 2007 - 2025 Michel Gaudry <michel@ladecadanse.ch>
+ * @license    AGPL License; see LICENSE file for details.
+ */
+
+namespace Ladecadanse;
+
+use Ladecadanse\Evenement;
+use Ladecadanse\HtmlShrink;
+
+class EvenementCalendarRenderer
+{
+    private string $title;
+    private string $location;
+    private string $description;
+    private string $eventUrl;
+    private string $startCompact;
+    private string $startIso;
+    private string $endCompact;
+    private string $endIso;
+    private int $eventId;
+
+    public function __construct(array $event, string $site_full_url)
+    {
+        $even_lieu = Evenement::getLieu($event);
+
+        $this->eventId = (int) $event['e_idEvenement'];
+        $this->title = $event['e_titre'];
+        $this->location = $even_lieu['nom'] . " - " . HtmlShrink::adresseCompacteSelonContexte($even_lieu['region'], $even_lieu['localite'], $even_lieu['quartier'], $even_lieu['adresse']);
+        $this->description = mb_substr(strip_tags($event['e_description']), 0, 500);
+        $this->eventUrl = $site_full_url . "event/evenement.php?idE=" . $this->eventId;
+
+        $hasStart = ($event['e_horaire_debut'] != "0000-00-00 00:00:00");
+        $hasEnd = ($event['e_horaire_fin'] != "0000-00-00 00:00:00");
+
+        $startRaw = $hasStart ? $event['e_horaire_debut'] : $event['e_dateEvenement'];
+        $this->startCompact = date('Ymd\THis', strtotime($startRaw));
+        $this->startIso = date('Y-m-d\TH:i:s', strtotime($startRaw));
+
+        $this->endCompact = '';
+        $this->endIso = '';
+        if ($hasEnd)
+        {
+            $this->endCompact = date('Ymd\THis', strtotime($event['e_horaire_fin']));
+            $this->endIso = date('Y-m-d\TH:i:s', strtotime($event['e_horaire_fin']));
+        }
+    }
+
+    /**
+     * @return array<string, string> URLs keyed by provider name
+     */
+    public function getLinks(): array
+    {
+        return [
+            'google' => $this->googleUrl(),
+            'outlook' => $this->outlookUrl(),
+            'office365' => $this->office365Url(),
+            'yahoo' => $this->yahooUrl(),
+            'ical' => $this->icalUrl(),
+        ];
+    }
+
+    public function googleUrl(): string
+    {
+        $dates = $this->endCompact
+            ? ($this->startCompact . '/' . $this->endCompact)
+            : ($this->startCompact . '/' . $this->startCompact);
+
+        return 'https://calendar.google.com/calendar/render?action=TEMPLATE'
+            . '&text=' . rawurlencode($this->title)
+            . '&dates=' . rawurlencode($dates)
+            . '&location=' . rawurlencode($this->location)
+            . '&details=' . rawurlencode($this->details());
+    }
+
+    public function outlookUrl(): string
+    {
+        return 'https://outlook.live.com/calendar/0/action/compose?' . $this->outlookParams();
+    }
+
+    public function office365Url(): string
+    {
+        return 'https://outlook.office.com/calendar/0/action/compose?' . $this->outlookParams();
+    }
+
+    public function yahooUrl(): string
+    {
+        return 'https://calendar.yahoo.com/?v=60'
+            . '&title=' . rawurlencode($this->title)
+            . '&st=' . rawurlencode($this->startCompact)
+            . ($this->endCompact ? '&et=' . rawurlencode($this->endCompact) : '')
+            . '&in_loc=' . rawurlencode($this->location)
+            . '&desc=' . rawurlencode($this->details());
+    }
+
+    public function icalUrl(): string
+    {
+        return '/event/to-ics.php?idE=' . $this->eventId;
+    }
+
+    private function outlookParams(): string
+    {
+        return 'subject=' . rawurlencode($this->title)
+            . '&startdt=' . rawurlencode($this->startIso)
+            . ($this->endIso ? '&enddt=' . rawurlencode($this->endIso) : '')
+            . '&location=' . rawurlencode($this->location)
+            . '&body=' . rawurlencode($this->details());
+    }
+
+    private function details(): string
+    {
+        return $this->description . "\n\n" . $this->eventUrl;
+    }
+}

--- a/web/css/global.css
+++ b/web/css/global.css
@@ -1123,7 +1123,48 @@ ul.menu_action
             vertical-align: middle;
         }
 
+.calendar-export-wrapper
+{
+    position: relative;
+    display: inline-block;
+}
 
+.calendar-export-menu
+{
+    position: absolute;
+    left: 0;
+    background: #fff;
+    border: 1px solid #ccc;
+    list-style: none;
+    padding: 0;
+    margin: 0.2em 0 0 0;
+    z-index: 10;
+    min-width: 12em;
+    text-align: left;
+}
+
+.calendar-export-wrapper ul.calendar-export-menu li
+{
+    display: block;
+    margin: 0;
+    padding: 0;
+    height: auto;
+    width: auto;
+    line-height: 1;
+}
+
+.calendar-export-wrapper ul.calendar-export-menu li a
+{
+    display: block;
+    padding: 0.9em 1.2em;
+    white-space: nowrap;
+    text-decoration: none;
+}
+
+.calendar-export-wrapper ul.calendar-export-menu li a:hover
+{
+    background: #f0f0f0;
+}
 
 
 ul.menu_edition

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -323,6 +323,18 @@ ul.menu_actions_evenement li.format_imprimable, #entete_contenu ul li.format_imp
     display:none;
 }
 
+ul.menu_action li a,
+ul.menu_actions_evenement .calendar-export-wrapper a.dropdown
+{
+    padding: 0.5em;
+    font-size: 1.2em;
+}
+
+.calendar-export-menu li a
+{
+    padding: 0.6em 1em;
+}
+
 a.url, #evenement #pratique .lien_ext
 {
     word-wrap: break-word;


### PR DESCRIPTION
## Summary
- Replace single iCal link with dropdown offering 5 calendar providers
- Google Calendar, Outlook.com, Microsoft 365, Yahoo via URL schemes (no library)
- iCal/Apple via existing to-ics.php endpoint
- Shared template (_calendar_export.inc.php) with compact (icon) and full (label) modes
- Dropdown on event page and agenda listing
- Mobile: larger touch targets for icons and menu items

Closes #57