### PR TITLE
feat(agenda): add genre tab navigation (#107)

### DIFF
--- a/index.php
+++ b/index.php
@@ -50,6 +50,7 @@ if (isset($_GET['genre_tab']) && in_array($_GET['genre_tab'], $valid_genre_tabs,
 }
 $current_genre_tab = $_SESSION['user_prefs_agenda_genre'] ?? 'tous';
 
+// determine wether adding to url query courant and order
 $default_tri_agenda = reset($tab_tri_agenda);
 $url_courant_param = (!$is_courant_today ? '&amp;courant=' . sanitizeForHtml($get['courant']) : '');
 $url_tri_param = ($_SESSION['user_prefs_agenda_order'] !== $default_tri_agenda ? '&amp;tri_agenda=' . sanitizeForHtml($_SESSION['user_prefs_agenda_order']) : '');
@@ -250,15 +251,20 @@ include("_header.inc.php");
             <div class="spacer"></div>
         </div>
 
-        <nav id="genre_tab_navigation">
+        <div id="genre_tab_navigation">
             <ul>
-                <li class="<?= $current_genre_tab === 'tous' ? 'ici' : '' ?>"><a href="index.php?genre_tab=tous<?= $url_filter_params ?>">Tous</a></li>
+                <li class="all">
+                    <i class="fa fa-filter" aria-hidden="true"></i>
+                    <?php if ($current_genre_tab !== 'tous') : ?>
+                        <a href="index.php?genre_tab=tous<?= $url_filter_params ?>"><i class="fa fa-times" aria-hidden="true"></i></a>
+                    <?php endif; ?>
+                </li>
                 <?php foreach ($glo_tab_genre as $key => $label) : ?>
                     <?php if (!array_key_exists($key, $tab_events_today_in_region_by_category)) : continue; endif; ?>
                     <li class="<?= $current_genre_tab === $key ? 'ici' : '' ?>"><a href="index.php?genre_tab=<?= urlencode($key) ?><?= $url_filter_params ?>"><?= ucfirst($label) ?></a></li>
                 <?php endforeach; ?>
             </ul>
-        </nav>
+        </div>
 
         <?php
         if ($count_events_today_in_region == 0)
@@ -279,10 +285,10 @@ include("_header.inc.php");
                     <header class="genre-titre">
                         <h2 id="<?= Text::stripAccents($glo_tab_genre[$genre]); ?>"><?= ucfirst($glo_tab_genre[$genre]); ?></h2>
                         <?php if ($current_genre_tab === 'tous') : ?>
-                        <?php $genre_proch = next($genres_today); ?>
-                        <?php if (isset($tab_events_today_in_region_by_category[$genre_proch])) : ?>
-                            <a class="genre-jump" href="#<?= Text::stripAccents($glo_tab_genre[$genre_proch]); ?>"><?= $glo_tab_genre[$genre_proch]; ?>&nbsp;<i class="fa fa-long-arrow-down"></i></a>
-                        <?php endif; ?>
+                            <?php $genre_proch = next($genres_today); ?>
+                            <?php if (isset($tab_events_today_in_region_by_category[$genre_proch])) : ?>
+                                <a class="genre-jump" href="#<?= Text::stripAccents($glo_tab_genre[$genre_proch]); ?>"><?= $glo_tab_genre[$genre_proch]; ?>&nbsp;<i class="fa fa-long-arrow-down"></i></a>
+                            <?php endif; ?>
                         <?php endif; ?>
                         <div class="spacer"></div>
                     </header>

--- a/index.php
+++ b/index.php
@@ -44,6 +44,18 @@ if (isset($_GET['tri_agenda']) && in_array($_GET['tri_agenda'], $tab_tri_agenda)
 {
    $_SESSION['user_prefs_agenda_order'] = $_GET['tri_agenda'];
 }
+
+$valid_genre_tabs = array_merge(['tous'], array_keys($glo_tab_genre));
+if (isset($_GET['genre_tab']) && in_array($_GET['genre_tab'], $valid_genre_tabs, true)) {
+    $_SESSION['user_prefs_agenda_genre'] = $_GET['genre_tab'];
+}
+$current_genre_tab = $_SESSION['user_prefs_agenda_genre'] ?? 'tous';
+
+$default_tri_agenda = reset($tab_tri_agenda);
+$url_courant_param = (!$is_courant_today ? '&amp;courant=' . sanitizeForHtml($get['courant']) : '');
+$url_tri_param = ($_SESSION['user_prefs_agenda_order'] !== $default_tri_agenda ? '&amp;tri_agenda=' . sanitizeForHtml($_SESSION['user_prefs_agenda_order']) : '');
+$url_filter_params = $url_courant_param . $url_tri_param;
+
 // build SQL
 $is_chronological_order = ($_SESSION['user_prefs_agenda_order'] == "horaire_debut");
 $sql_user_prefs_agenda_order = "e." . $_SESSION['user_prefs_agenda_order'] . " DESC";
@@ -240,6 +252,16 @@ include("_header.inc.php");
             <div class="spacer"></div>
         </div>
 
+        <nav id="genre_tab_navigation">
+            <ul>
+                <li class="<?= $current_genre_tab === 'tous' ? 'ici' : '' ?>"><a href="index.php?genre_tab=tous<?= $url_filter_params ?>">Tous</a></li>
+                <?php foreach ($glo_tab_genre as $key => $label) : ?>
+                    <?php if (!array_key_exists($key, $tab_events_today_in_region_by_category)) : continue; endif; ?>
+                    <li class="<?= $current_genre_tab === $key ? 'ici' : '' ?>"><a href="index.php?genre_tab=<?= urlencode($key) ?><?= $url_filter_params ?>"><?= ucfirst($label) ?></a></li>
+                <?php endforeach; ?>
+            </ul>
+        </nav>
+
         <?php
         if ($count_events_today_in_region == 0)
         {
@@ -249,15 +271,19 @@ include("_header.inc.php");
         $genres_today = array_keys($tab_events_today_in_region_by_category);
         foreach ($tab_events_today_in_region_by_category as $genre => $tab_genre_events)
         {
+            if ($current_genre_tab !== 'tous' && $genre !== $current_genre_tab) {
+                continue;
+            }
             ?>
                 <section class="genre">
 
                     <header class="genre-titre">
                         <h2 id="<?= Text::stripAccents($glo_tab_genre[$genre]); ?>"><?= ucfirst($glo_tab_genre[$genre]); ?></h2>
-                        <?php
-                        $genre_proch = next($genres_today);
-                        if (isset($tab_events_today_in_region_by_category[$genre_proch])) : ?>
+                        <?php if ($current_genre_tab === 'tous') : ?>
+                        <?php $genre_proch = next($genres_today); ?>
+                        <?php if (isset($tab_events_today_in_region_by_category[$genre_proch])) : ?>
                             <a class="genre-jump" href="#<?= Text::stripAccents($glo_tab_genre[$genre_proch]); ?>"><?= $glo_tab_genre[$genre_proch]; ?>&nbsp;<i class="fa fa-long-arrow-down"></i></a>
+                        <?php endif; ?>
                         <?php endif; ?>
                         <div class="spacer"></div>
                     </header>

--- a/index.php
+++ b/index.php
@@ -253,25 +253,30 @@ include("_header.inc.php");
             <div class="spacer"></div>
         </div>
 
+        <?php if ($count_events_today_in_region > 0) : ?>
         <div id="genre_tab_navigation">
             <ul>
-                <li class="all">
-                    <i class="fa fa-filter" aria-hidden="true"></i>
-                    <?php if ($current_genre_tab !== 'tous') : ?>
-                        <a href="index.php?genre_tab=tous<?= $url_filter_params ?>"><i class="fa fa-times" aria-hidden="true"></i></a>
-                    <?php endif; ?>
-                </li>
+                <li class="all"><i class="fa fa-filter" aria-hidden="true"></i></li>
                 <?php foreach ($glo_tab_genre as $key => $label) : ?>
-                    <?php if (!array_key_exists($key, $tab_events_today_in_region_by_category)) : continue; endif; ?>
-                    <li class="<?= $current_genre_tab === $key ? 'ici' : '' ?>"><a href="index.php?genre_tab=<?= urlencode($key) ?><?= $url_filter_params ?>"><?= ucfirst($label) ?></a></li>
+                    <?php if (!array_key_exists($key, $tab_events_today_in_region_by_category) && $current_genre_tab !== $key) : continue; endif; ?>
+                    <?php if ($current_genre_tab === $key) : ?>
+                        <li class="ici"><a href="index.php?genre_tab=tous<?= $url_filter_params ?>" title="Retirer le filtre"><?= ucfirst($label) ?>&nbsp;<i class="fa fa-times" aria-hidden="true"></i></a></li>
+                    <?php else : ?>
+                        <li><a href="index.php?genre_tab=<?= urlencode($key) ?><?= $url_filter_params ?>"><?= ucfirst($label) ?></a></li>
+                    <?php endif; ?>
                 <?php endforeach; ?>
             </ul>
         </div>
+        <?php endif; ?>
 
         <?php
         if ($count_events_today_in_region == 0)
         {
             HtmlShrink::msgInfo("Pas d’événement prévu ce jour");
+        }
+        elseif ($current_genre_tab !== 'tous' && !array_key_exists($current_genre_tab, $tab_events_today_in_region_by_category))
+        {
+            HtmlShrink::msgInfo("Pas d’événement « " . ucfirst($glo_tab_genre[$current_genre_tab]) . " » prévu ce jour");
         }
 
         $genres_today = array_keys($tab_events_today_in_region_by_category);

--- a/index.php
+++ b/index.php
@@ -51,6 +51,7 @@ if (isset($_GET['genre_tab']) && in_array($_GET['genre_tab'], $valid_genre_tabs,
 }
 $current_genre_tab = $_SESSION['user_prefs_agenda_genre'] ?? 'tous';
 
+// determine wether adding to url query courant and order
 $default_tri_agenda = reset($tab_tri_agenda);
 $url_courant_param = (!$is_courant_today ? '&amp;courant=' . sanitizeForHtml($get['courant']) : '');
 $url_tri_param = ($_SESSION['user_prefs_agenda_order'] !== $default_tri_agenda ? '&amp;tri_agenda=' . sanitizeForHtml($_SESSION['user_prefs_agenda_order']) : '');
@@ -252,15 +253,20 @@ include("_header.inc.php");
             <div class="spacer"></div>
         </div>
 
-        <nav id="genre_tab_navigation">
+        <div id="genre_tab_navigation">
             <ul>
-                <li class="<?= $current_genre_tab === 'tous' ? 'ici' : '' ?>"><a href="index.php?genre_tab=tous<?= $url_filter_params ?>">Tous</a></li>
+                <li class="all">
+                    <i class="fa fa-filter" aria-hidden="true"></i>
+                    <?php if ($current_genre_tab !== 'tous') : ?>
+                        <a href="index.php?genre_tab=tous<?= $url_filter_params ?>"><i class="fa fa-times" aria-hidden="true"></i></a>
+                    <?php endif; ?>
+                </li>
                 <?php foreach ($glo_tab_genre as $key => $label) : ?>
                     <?php if (!array_key_exists($key, $tab_events_today_in_region_by_category)) : continue; endif; ?>
                     <li class="<?= $current_genre_tab === $key ? 'ici' : '' ?>"><a href="index.php?genre_tab=<?= urlencode($key) ?><?= $url_filter_params ?>"><?= ucfirst($label) ?></a></li>
                 <?php endforeach; ?>
             </ul>
-        </nav>
+        </div>
 
         <?php
         if ($count_events_today_in_region == 0)
@@ -280,10 +286,10 @@ include("_header.inc.php");
                     <header class="genre-titre">
                         <h2 id="<?= Text::stripAccents($glo_tab_genre[$genre]); ?>"><?= ucfirst($glo_tab_genre[$genre]); ?></h2>
                         <?php if ($current_genre_tab === 'tous') : ?>
-                        <?php $genre_proch = next($genres_today); ?>
-                        <?php if (isset($tab_events_today_in_region_by_category[$genre_proch])) : ?>
-                            <a class="genre-jump" href="#<?= Text::stripAccents($glo_tab_genre[$genre_proch]); ?>"><?= $glo_tab_genre[$genre_proch]; ?>&nbsp;<i class="fa fa-long-arrow-down"></i></a>
-                        <?php endif; ?>
+                            <?php $genre_proch = next($genres_today); ?>
+                            <?php if (isset($tab_events_today_in_region_by_category[$genre_proch])) : ?>
+                                <a class="genre-jump" href="#<?= Text::stripAccents($glo_tab_genre[$genre_proch]); ?>"><?= $glo_tab_genre[$genre_proch]; ?>&nbsp;<i class="fa fa-long-arrow-down"></i></a>
+                            <?php endif; ?>
                         <?php endif; ?>
                         <div class="spacer"></div>
                     </header>

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -1,3 +1,44 @@
+#genre_tab_navigation
+{
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: #fff;
+    padding: 0.6em 0;
+    border-top: 1px solid #ccc;
+    border-bottom: 1px dotted #ccc;
+    margin-bottom: 0.8em;
+}
+
+#genre_tab_navigation ul
+{
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+#genre_tab_navigation li
+{
+    display: inline;
+}
+
+#genre_tab_navigation li + li::before
+{
+    content: " | ";
+    color: #aaa;
+}
+
+#genre_tab_navigation li a
+{
+    color: #6086B1;
+}
+
+#genre_tab_navigation li.ici a
+{
+    color: #333;
+    font-weight: bold;
+}
+
 header#entete_contenu h1
 {
     float:left;

--- a/web/css/index.css
+++ b/web/css/index.css
@@ -5,8 +5,7 @@
     z-index: 10;
     background: #fff;
     padding: 0.6em 0;
-    border-top: 1px solid #ccc;
-    border-bottom: 1px dotted #ccc;
+    margin-top: 0.8em;
     margin-bottom: 0.8em;
 }
 
@@ -19,25 +18,27 @@
 
 #genre_tab_navigation li
 {
-    display: inline;
-}
-
-#genre_tab_navigation li + li::before
-{
-    content: " | ";
-    color: #aaa;
+    display: inline-block;
+    padding-left:0.2em;
+    padding-right:0.2em;
 }
 
 #genre_tab_navigation li a
 {
-    color: #6086B1;
+    padding: 0.3em;
+    border-radius:3px;
+}
+
+#genre_tab_navigation li a:hover
+{
+    background: #d4d4d4
 }
 
 #genre_tab_navigation li.ici a
 {
-    color: #333;
-    font-weight: bold;
+    background: #eee;
 }
+
 
 header#entete_contenu h1
 {


### PR DESCRIPTION
Add a sticky, pipe-separated genre filter bar below the sort controls. Selected genre is persisted in SESSION and encoded in the URL for back-navigation support. Sort and date params are preserved across tab switches.