### PR TITLE
feat(event): export to calendar links in search, lieu, organisateur pages (#150)

### DIFF
--- a/event/evenement.php
+++ b/event/evenement.php
@@ -196,10 +196,7 @@ include("../_header.inc.php");
             <?php if ((isset($_SESSION['Sgroupe']) && $_SESSION['Sgroupe'] <= UserLevel::MEMBER)) : ?>
                 <li><a href="/event/send.php?action=share&idE=<?= (int) $get['idE'] ?>"><?= $icone['envoi_email'] ?>&nbsp;Envoyer à un ami</a></li>
             <?php endif; ?>
-            <?php
-            $calLinks = (new Ladecadanse\EvenementCalendarRenderer($tab_even, $site_full_url))->getLinks();
-            include("_calendar_export.inc.php");
-            ?>
+            <?= Ladecadanse\EvenementCalendarRenderer::renderMenuHtml($tab_even, $site_full_url) ?>
             <?php if ($isPersonneAllowedToEdit) : ?>
                 <li><a href="/event/copy.php?idE=<?= (int) $get['idE'] ?>"><?= $iconeCopier ?>&nbsp;Copier vers d'autres dates</a></li>
                 <li><a href="/evenement-edit.php?action=editer&amp;idE=<?= (int) $get['idE'] ?>"><?= $iconeEditer ?>&nbsp;Modifier</a></li>

--- a/event/search.php
+++ b/event/search.php
@@ -1,9 +1,10 @@
 <?php
 
-global $connector, $glo_regions, $glo_auj, $iconeEditer, $glo_auj_6h;
+global $connector, $glo_regions, $glo_auj, $iconeEditer, $glo_auj_6h, $site_full_url;
 
 require_once("../app/bootstrap.php");
 
+use Ladecadanse\EvenementCalendarRenderer;
 use Ladecadanse\HtmlShrink;
 use Ladecadanse\Utils\DateHelper;
 use Ladecadanse\Utils\Utils;
@@ -273,8 +274,21 @@ $agenda_years = range((int)date("Y"), Evenement::AGENDA_START_YEAR);
                             <?php if ((isset($_SESSION['Sgroupe']) && $_SESSION['Sgroupe'] == UserLevel::SUPERADMIN)) : ?>
                             <td><?= round($tab_even['score'], 5) ?></td>
                             <?php endif; ?>
-                            <?php if ($authorization->isPersonneAllowedToEditEvenement($_SESSION, $tab_even)) : ?>
-                                <td><a href="/evenement-edit.php?action=editer&amp;idE=<?= (int) $tab_even['e_idEvenement'] ?>"><?= $iconeEditer; ?></a></td>
+                            <?php
+                            $isFutureEvent = $even_periode !== 'ancien';
+                            $isAllowedToEdit = $authorization->isPersonneAllowedToEditEvenement($_SESSION, $tab_even);
+                            ?>
+                            <?php if ($isFutureEvent || $isAllowedToEdit) : ?>
+                                <td class="lieu_actions_evenement">
+                                    <ul>
+                                        <?php if ($isFutureEvent) : ?>
+                                            <?= EvenementCalendarRenderer::renderMenuHtml($tab_even, $site_full_url, compact: true) ?>
+                                        <?php endif; ?>
+                                        <?php if ($isAllowedToEdit) : ?>
+                                            <li><a href="/evenement-edit.php?action=editer&amp;idE=<?= (int) $tab_even['e_idEvenement'] ?>"><?= $iconeEditer; ?></a></li>
+                                        <?php endif; ?>
+                                    </ul>
+                                </td>
                             <?php endif; ?>
                         </tr>
                     <?php endforeach; ?>

--- a/index.php
+++ b/index.php
@@ -278,13 +278,7 @@ include("_header.inc.php");
 
                                 <ul class="menu_action">
                                     <li><a href="/event/send.php?action=report&idE=<?= (int) $tab_even['e_idEvenement']; ?>" class="signaler" title="Signaler une erreur"><i class="fa fa-flag-o fa-lg"></i></a></li>
-                                    <?php
-                                    $calLinks = (new Ladecadanse\EvenementCalendarRenderer($tab_even, $site_full_url))->getLinks();
-                                    $calExportCompact = true;
-                                    $calExportId = (int) $tab_even['e_idEvenement'];
-                                    include("event/_calendar_export.inc.php");
-                                    unset($calExportCompact, $calExportId);
-                                    ?>
+                                    <?= Ladecadanse\EvenementCalendarRenderer::renderMenuHtml($tab_even, $site_full_url, compact: true) ?>
                                 </ul>
 
                                 <?php if ($authorization->isPersonneAllowedToEditEvenement($_SESSION, $tab_even)) : ?>

--- a/librairies/EvenementCalendarRenderer.php
+++ b/librairies/EvenementCalendarRenderer.php
@@ -63,6 +63,20 @@ class EvenementCalendarRenderer
         ];
     }
 
+    /**
+     * @param array<string, mixed> $event Event row with at least `e_idEvenement`, `e_horaire_debut`, `e_horaire_fin`, `e_dateEvenement`, `e_titre`, `e_description`, `e_idLieu` and lieu fields from a JOIN
+     * @param bool $compact icon-only trigger with tooltip if true; full label otherwise
+     */
+    public static function renderMenuHtml(array $event, string $siteFullUrl, bool $compact = false): string
+    {
+        $calLinks = (new self($event, $siteFullUrl))->getLinks();
+        $calExportCompact = $compact;
+        $calExportId = (int) $event['e_idEvenement'];
+        ob_start();
+        include __DIR__ . "/../event/_calendar_export.inc.php";
+        return ob_get_clean();
+    }
+
     public function googleUrl(): string
     {
         $dates = $this->endCompact

--- a/librairies/EvenementRenderer.php
+++ b/librairies/EvenementRenderer.php
@@ -9,6 +9,7 @@
 namespace Ladecadanse;
 
 use Ladecadanse\Evenement;
+use Ladecadanse\EvenementCalendarRenderer;
 use Ladecadanse\HtmlShrink;
 use Ladecadanse\Lieu;
 use Ladecadanse\Organisateur;
@@ -247,7 +248,10 @@ class EvenementRenderer
     public static function eventTableRowHtml(array $tab_even, Authorization $authorization, bool $isWithLieu): string
     {
         // TODO: mv $glo_tab_genre to a class constant; $icone... to... ?
-        global $glo_tab_genre, $glo_auj_6h, $iconeCopier, $iconeEditer, $icone;
+        global $glo_tab_genre, $glo_auj_6h, $iconeCopier, $iconeEditer, $icone, $site_full_url;
+
+        $isFutureEvent = $tab_even['e_dateEvenement'] >= $glo_auj_6h;
+        $isAllowedToEdit = $authorization->isPersonneAllowedToEditEvenement($_SESSION, $tab_even);
 
         $vcard_starttime = '';
         if (mb_substr((string) $tab_even['e_horaire_debut'], 11, 5) != '06:00')
@@ -287,12 +291,17 @@ class EvenementRenderer
                     </div>
                 <?php endif; ?>
             </td>
-            <?php if ($authorization->isPersonneAllowedToEditEvenement($_SESSION, $tab_even)) : ?>
+            <?php if ($isFutureEvent || $isAllowedToEdit) : ?>
             <td class="lieu_actions_evenement">
                 <ul>
-                    <li><a href="/event/copy.php?idE=<?= (int) $tab_even['e_idEvenement'] ?>" title="Copier cet événement"><?= $iconeCopier ?></a></li>
-                    <li><a href="/evenement-edit.php?action=editer&amp;idE=<?= (int) $tab_even['e_idEvenement'] ?>" title="Modifier cet événement"><?= $iconeEditer ?></a></li>
-                    <li class=""><a href="#" id="btn_event_unpublish_<?= (int) $tab_even['e_idEvenement'] ?>" class="btn_event_unpublish" data-id="<?= (int) $tab_even['e_idEvenement'] ?>"><?= $icone['depublier']; ?></a></li>
+                    <?php if ($isFutureEvent) : ?>
+                        <?= EvenementCalendarRenderer::renderMenuHtml($tab_even, $site_full_url, compact: true) ?>
+                    <?php endif; ?>
+                    <?php if ($isAllowedToEdit) : ?>
+                        <li><a href="/event/copy.php?idE=<?= (int) $tab_even['e_idEvenement'] ?>" title="Copier cet événement"><?= $iconeCopier ?></a></li>
+                        <li><a href="/evenement-edit.php?action=editer&amp;idE=<?= (int) $tab_even['e_idEvenement'] ?>" title="Modifier cet événement"><?= $iconeEditer ?></a></li>
+                        <li class=""><a href="#" id="btn_event_unpublish_<?= (int) $tab_even['e_idEvenement'] ?>" class="btn_event_unpublish" data-id="<?= (int) $tab_even['e_idEvenement'] ?>"><?= $icone['depublier']; ?></a></li>
+                    <?php endif; ?>
                 </ul>
 
             </td>

--- a/lieu/lieu.php
+++ b/lieu/lieu.php
@@ -87,9 +87,18 @@ $sql_select = "SELECT
   e.region AS e_region,
   e.urlLieu AS e_urlLieu,
 
+  l.nom AS l_nom,
+  l.adresse AS l_adresse,
+  l.quartier AS l_quartier,
+  l.URL AS l_URL,
+  l.region AS l_region,
+  lloc.localite AS lloc_localite,
+
   s.nom AS s_nom
 
 FROM evenement e
+LEFT JOIN lieu l ON e.idLieu = l.idLieu
+LEFT JOIN localite lloc ON l.localite_id = lloc.id
 LEFT JOIN salle s ON e.idSalle = s.idSalle
 WHERE
     e.statut NOT IN ('inactif', 'propose') AND e.idLieu = ?";

--- a/web/css/global.css
+++ b/web/css/global.css
@@ -1232,6 +1232,45 @@ ul.menu_action
     background: #f0f0f0;
 }
 
+td.lieu_actions_evenement ul
+{
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+td.lieu_actions_evenement li
+{
+    display: inline-block;
+    margin: 0 0.15em;
+    vertical-align: middle;
+}
+
+td.lieu_actions_evenement li img
+{
+    vertical-align: middle;
+}
+
+td.lieu_actions_evenement .calendar-export-trigger
+{
+    display: inline-block;
+    line-height: 1;
+    vertical-align: middle;
+    color: #a6a5a5;
+}
+
+td.lieu_actions_evenement .calendar-export-trigger i
+{
+    display: block;
+    font-size: 16px;
+    line-height: 1;
+}
+
+td.lieu_actions_evenement .calendar-export-trigger:hover,
+td.lieu_actions_evenement .calendar-export-trigger:active
+{
+    color: #1569C7;
+}
 
 ul.menu_edition
 {

--- a/web/css/lieu/lieu.css
+++ b/web/css/lieu/lieu.css
@@ -473,19 +473,3 @@ ul#menu_complement
             background-color:transparent;
             }*/
 
-            #prochains_evenements table td.lieu_actions_evenement
-            {
-                width:60px
-            }
-
-                #prochains_evenements table td.lieu_actions_evenement ul
-                {
-                    padding: 0;
-                    margin:0;
-                }
-
-                    #prochains_evenements table td.lieu_actions_evenement ul li
-                    {
-                        display:inline;
-
-                    }

--- a/web/css/organisateur/organisateur.css
+++ b/web/css/organisateur/organisateur.css
@@ -456,19 +456,3 @@ ul#menu_complement .rss
             background-color:transparent;
             }*/
 
-            #prochains_evenements table td.lieu_actions_evenement
-            {
-                width:60px
-            }
-
-                #prochains_evenements table td.lieu_actions_evenement ul
-                {
-                    padding: 0;
-                    margin:0;
-                }
-
-                    #prochains_evenements table td.lieu_actions_evenement ul li
-                    {
-                        display:inline;
-
-                    }


### PR DESCRIPTION
## Summary

Closes #150

Adds the calendar export popover (Google Calendar, Outlook.com, Microsoft 365, Yahoo, iCal/Apple) to event listings on the **search**, **lieu**, and **organisateur** pages, extending the work done in PR #142 for the event detail page and the agenda.

The export icon is shown:
- in the `<td class="lieu_actions_evenement">` cell, as suggested in the issue
- for all users (logged in or not)
- only for future events (today or later)

## Changes

- **`librairies/EvenementRenderer.php`** (`eventTableRowHtml` method, used by `lieu.php` and `organisateur.php`): the `lieu_actions_evenement` cell is now always rendered. Calendar export shows for future events for all users. Edit/copy/depublish actions stay conditional on edit rights.
- **`event/search.php`**: new `lieu_actions_evenement` cell with the same logic (calendar export for future or today events, edit link if allowed).
- **`lieu/lieu.php`**: the SQL now joins `lieu` and `localite` tables (`l_*`, `lloc_*` aliases) so `EvenementCalendarRenderer` can build the event location string.

## Test plan

- [x] Lieu page with a future event: calendar export icon and popover render correctly
- [x] Lieu page with past events: empty actions cell as expected
- [x] Search page with a future event: calendar export icon and popover render correctly
- [ ] Organisateur page with a future event (not testable on the dev DB which has no organisateurs, but uses the same shared renderer as lieu)
- [x] No PHP syntax errors on the 3 modified files