### PR TITLE
feat(events): warn on near-duplicate event creation (closes #175)

### DIFF
--- a/evenement-edit.php
+++ b/evenement-edit.php
@@ -899,7 +899,9 @@ if ($verif->nbErreurs() > 0)
             <input type="text" name="name_as" value="" class="name_as" /><?php echo $verif->getHtmlErreur('name_as'); ?>
             <input type="hidden" name="<?php echo $formTokenName; ?>" value="<?php echo sanitizeForHtml($_SESSION[$formTokenName]); ?>">
 
-            <?php if (!empty($similarEvenements)) : ?>
+            <?php if (!empty($similarEvenements)) :
+                $someSimilarEditable = false;
+                $someSimilarNotEditable = false; ?>
             <aside class="duplicate-warning">
                 <h2>Cet événement existe peut&#8209;être déjà</h2>
                 <p>Un ou plusieurs événements similaires ont déjà été créés à ce lieu pour cette date&nbsp;:</p>
@@ -910,11 +912,24 @@ if ($verif->nbErreurs() > 0)
                             $similar['horaire_fin'],
                             $similar['dateEvenement']
                         );
+                        $canEditSimilar = $authorization->isPersonneAllowedToEditEvenement($_SESSION, [
+                            'e_idEvenement' => $similar['idEvenement'],
+                            'e_idLieu' => $similar['idLieu'],
+                            'e_idPersonne' => $similar['idPersonne'],
+                        ]);
+                        if ($canEditSimilar) {
+                            $someSimilarEditable = true;
+                        } else {
+                            $someSimilarNotEditable = true;
+                        }
                         ?>
                         <li>
                             <a href="/event/evenement.php?idE=<?= (int) $similar['idEvenement'] ?>" target="_blank">
                                 «&nbsp;<?= sanitizeForHtml($similar['titre']) ?>&nbsp;»
                             </a>
+                            <?php if ($canEditSimilar) : ?>
+                                <a class="duplicate-edit" href="/evenement-edit.php?action=editer&amp;idE=<?= (int) $similar['idEvenement'] ?>" title="Éditer l’événement"><?= $iconeEditer ?></a>
+                            <?php endif; ?>
                             <?php if (!empty($horaireSimilar)) : ?>
                                 <span class="horaire"><?= sanitizeForHtml($horaireSimilar) ?></span>
                             <?php endif; ?>
@@ -924,7 +939,12 @@ if ($verif->nbErreurs() > 0)
                         </li>
                     <?php endforeach; ?>
                 </ul>
-                <p>Si c’est la même chose, <strong>modifiez l’événement existant</strong> en cliquant sur son titre ci&#8209;dessus.</p>
+                <?php if ($someSimilarEditable) : ?>
+                <p>S’il s’agit d’un duplicat, <strong>modifiez l’événement existant</strong> à l’aide de l’icône d’édition à côté de son titre.</p>
+                <?php endif; ?>
+                <?php if ($someSimilarNotEditable) : ?>
+                <p>Vous n’avez pas les droits pour modifier certains de ces événements&nbsp;: contactez l’organisateur qui l’a ajouté, ou en dernier recours les webmasters de La décadanse.</p>
+                <?php endif; ?>
                 <div class="confirm-row">
                     <label class="confirm-label">
                         <input type="checkbox" name="confirm_duplicate" value="1">

--- a/evenement-edit.php
+++ b/evenement-edit.php
@@ -112,6 +112,7 @@ $show_form = true;
 $formTokenName = 'form_token_evenement_edit';
 $verif = new Validateur();
 $fichiers = ['flyer' => ['name' => '', 'size' => 0], 'image' => ['name' => '', 'size' => 0]];
+$similarEvenements = [];
 
 if (isset($_POST['formulaire']) && $_POST['formulaire'] === 'ok')
 {
@@ -308,8 +309,21 @@ if (isset($_POST['formulaire']) && $_POST['formulaire'] === 'ok')
         $verif->valider($champs['description'], "description", "texte", 4, 10000, 0);
     }
 
-    // valide : insert or update
-    if ($verif->nbErreurs() === 0)
+    if ($verif->nbErreurs() === 0
+        && empty($_POST['confirm_duplicate'])
+        && $get['action'] === 'insert'
+        && isset($date_iso)
+    )
+    {
+        $similarEvenements = Evenement::findSimilarEvenements(
+            (string) $champs['titre'],
+            (int) $champs['idLieu'],
+            (string) $champs['nomLieu'],
+            $date_iso,
+        );
+    }
+
+    if ($verif->nbErreurs() === 0 && empty($similarEvenements))
 	{
 		//creation/nettoyage des valeurs à insérer dans la table
 
@@ -884,6 +898,42 @@ if ($verif->nbErreurs() > 0)
 
             <input type="text" name="name_as" value="" class="name_as" /><?php echo $verif->getHtmlErreur('name_as'); ?>
             <input type="hidden" name="<?php echo $formTokenName; ?>" value="<?php echo sanitizeForHtml($_SESSION[$formTokenName]); ?>">
+
+            <?php if (!empty($similarEvenements)) : ?>
+            <aside class="duplicate-warning">
+                <h2>Cet événement existe peut&#8209;être déjà</h2>
+                <p>Un ou plusieurs événements similaires ont déjà été créés à ce lieu pour cette date&nbsp;:</p>
+                <ul class="duplicate-list">
+                    <?php foreach ($similarEvenements as $similar) :
+                        $horaireSimilar = EvenementRenderer::schedulesToHhMm(
+                            $similar['horaire_debut'],
+                            $similar['horaire_fin'],
+                            $similar['dateEvenement']
+                        );
+                        ?>
+                        <li>
+                            <a href="/event/evenement.php?idE=<?= (int) $similar['idEvenement'] ?>" target="_blank">
+                                «&nbsp;<?= sanitizeForHtml($similar['titre']) ?>&nbsp;»
+                            </a>
+                            <?php if (!empty($horaireSimilar)) : ?>
+                                <span class="horaire"><?= sanitizeForHtml($horaireSimilar) ?></span>
+                            <?php endif; ?>
+                            <?php if (!empty($similar['statut']) && $similar['statut'] !== 'actif') : ?>
+                                <span class="statut">[<?= sanitizeForHtml($similar['statut']) ?>]</span>
+                            <?php endif; ?>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+                <p>Si c’est la même chose, <strong>modifiez l’événement existant</strong> en cliquant sur son titre ci&#8209;dessus.</p>
+                <div class="confirm-row">
+                    <label class="confirm-label">
+                        <input type="checkbox" name="confirm_duplicate" value="1">
+                        <span>Il s’agit bien d’un autre événement, je confirme la création.</span>
+                    </label>
+                    <input type="submit" value="Confirmer" class="submit submit-big confirm-submit">
+                </div>
+            </aside>
+            <?php endif; ?>
 
             <div class="alert-warn">
                     <?php if (!in_array($get['action'], ['editer', 'update'])) { ?>

--- a/librairies/Evenement.php
+++ b/librairies/Evenement.php
@@ -5,6 +5,7 @@ namespace Ladecadanse;
 
 use Ladecadanse\Element;
 use Ladecadanse\HasDocuments;
+use Ladecadanse\Utils\Text;
 
 class Evenement extends Element
 {
@@ -58,6 +59,92 @@ class Evenement extends Element
                 'url' => $event['e_urlLieu'],
                 'salle' => ""
             ];
+    }
+
+    public static function normalizeTitre(string $titre): string
+    {
+        $stripped = Text::stripAccents($titre);
+        $lower = mb_strtolower($stripped, 'UTF-8');
+        $collapsed = preg_replace('/\s+/u', ' ', $lower);
+        return trim((string) $collapsed);
+    }
+
+    public static function findSimilarEvenements(
+        string $titre,
+        int $idLieu,
+        string $nomLieu,
+        string $dateEvenement,
+        int $excludeIdE = 0,
+        int $maxLevenshtein = 5,
+    ): array {
+        global $connectorPdo;
+
+        $normalizedTitre = self::normalizeTitre($titre);
+        if ($normalizedTitre === '')
+        {
+            return [];
+        }
+
+        $params = [
+            ':date' => $dateEvenement,
+            ':excludeIdE' => $excludeIdE,
+        ];
+
+        if ($idLieu <= 0 && $nomLieu === '')
+        {
+            return [];
+        }
+
+        if ($idLieu > 0)
+        {
+            $lieuClause = 'e.idLieu = :idLieu';
+            $params[':idLieu'] = $idLieu;
+        }
+        else
+        {
+            $lieuClause = 'e.idLieu = 0 AND LOWER(e.nomLieu) = :nomLieu';
+            $params[':nomLieu'] = mb_strtolower(trim($nomLieu), 'UTF-8');
+        }
+
+        $sql = "SELECT
+            e.idEvenement,
+            e.titre,
+            e.dateEvenement,
+            e.horaire_debut,
+            e.horaire_fin,
+            e.statut,
+            e.nomLieu,
+            l.nom AS l_nom
+        FROM evenement e
+        LEFT JOIN lieu l ON e.idLieu = l.idLieu
+        WHERE e.dateEvenement = :date
+            AND e.statut <> 'ancien'
+            AND e.idEvenement <> :excludeIdE
+            AND $lieuClause";
+
+        $stmt = $connectorPdo->prepare($sql);
+        $stmt->execute($params);
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        $similar = [];
+        foreach ($rows as $row)
+        {
+            $candidateNorm = self::normalizeTitre((string) $row['titre']);
+            if ($candidateNorm === '')
+            {
+                continue;
+            }
+            if (abs(strlen($normalizedTitre) - strlen($candidateNorm)) > $maxLevenshtein)
+            {
+                continue;
+            }
+            if (levenshtein($normalizedTitre, $candidateNorm) <= $maxLevenshtein)
+            {
+                $similar[] = $row;
+            }
+        }
+
+        return $similar;
     }
 
     public static function getFilePath(string $fileName, string $fileNamePrefix = '', string $fileNameSuffix = ''): string

--- a/librairies/Evenement.php
+++ b/librairies/Evenement.php
@@ -108,6 +108,8 @@ class Evenement extends Element
 
         $sql = "SELECT
             e.idEvenement,
+            e.idLieu,
+            e.idPersonne,
             e.titre,
             e.dateEvenement,
             e.horaire_debut,
@@ -118,7 +120,7 @@ class Evenement extends Element
         FROM evenement e
         LEFT JOIN lieu l ON e.idLieu = l.idLieu
         WHERE e.dateEvenement = :date
-            AND e.statut <> 'ancien'
+            AND e.statut NOT IN ('inactif', 'propose')
             AND e.idEvenement <> :excludeIdE
             AND $lieuClause";
 

--- a/tests/ladecadanse.side
+++ b/tests/ladecadanse.side
@@ -7946,6 +7946,276 @@
       "targets": [],
       "value": ""
     }]
+  }, {
+    "id": "de2e2d23-e992-4f76-a3c0-663b485ed1f9",
+    "name": "user (admin) event add duplicate detection (r)",
+    "commands": [{
+      "id": "dfd7375f-c499-4528-8be9-120d34f63f2d",
+      "comment": "Start fresh at home",
+      "command": "open",
+      "target": "/",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "de863460-cca6-4e17-bc86-085bb8aee197",
+      "comment": "",
+      "command": "click",
+      "target": "linkText=Ajouter un événement",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "543271a2-df47-4b66-9227-6522e6997f48",
+      "comment": "Form loaded",
+      "command": "assertElementPresent",
+      "target": "id=ajouter_editer",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "76fc7f43-5323-4c5c-8db5-4fa89049157e",
+      "comment": "Today as DD.MM.YYYY",
+      "command": "executeScript",
+      "target": "return (new Date().getDate().toString().padStart(2, '0')) + \".\" + ((new Date().getMonth() + 1).toString().padStart(2, '0')) + \".\" + ((new Date()).getFullYear() )",
+      "targets": [],
+      "value": "eventDate"
+    }, {
+      "id": "0f69d033-1408-4fd3-9a1f-581b0fff3ae3",
+      "comment": "Create first event",
+      "command": "click",
+      "target": "id=genre_divers",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "e90fc050-b408-4242-b1a7-ae32234caa44",
+      "comment": "",
+      "command": "type",
+      "target": "id=titre",
+      "targets": [],
+      "value": "Selenium doublon detection"
+    }, {
+      "id": "46037b17-5c69-4ef3-a70c-55b53552e3a8",
+      "comment": "",
+      "command": "type",
+      "target": "id=dateEvenement",
+      "targets": [],
+      "value": "${eventDate}"
+    }, {
+      "id": "11eb1b11-5c6b-4abb-82f0-e33f9540fa02",
+      "comment": "",
+      "command": "type",
+      "target": "id=description",
+      "targets": [],
+      "value": "Test Selenium pour la detection de doublons."
+    }, {
+      "id": "7deb9517-7f47-4f1a-839c-8feaf1f0f679",
+      "comment": "",
+      "command": "type",
+      "target": "id=horaire_debut",
+      "targets": [],
+      "value": "20:00"
+    }, {
+      "id": "f2e46ccc-708b-48b1-a413-2ef602135ded",
+      "comment": "",
+      "command": "type",
+      "target": "id=horaire_fin",
+      "targets": [],
+      "value": "22:00"
+    }, {
+      "id": "71933457-e189-4aa2-ba80-f553f1633894",
+      "comment": "Select existing lieu (sets idLieu, avoids adresse/localite_id requirement)",
+      "command": "select",
+      "target": "id=idLieu",
+      "targets": [],
+      "value": "label=Lieu Test Selenium"
+    }, {
+      "id": "08748364-c233-433b-beed-1f3bb289cb37",
+      "comment": "",
+      "command": "type",
+      "target": "id=prix",
+      "targets": [],
+      "value": "Libre"
+    }, {
+      "id": "318d7332-e75b-4f3b-a0d5-933c3bc4b13f",
+      "comment": "",
+      "command": "click",
+      "target": "name=submit",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "d682babd-7e5b-4e64-9779-81215f731581",
+      "comment": "",
+      "command": "pause",
+      "target": "3000",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "5ccfbafd-cfb1-4ace-9385-df6ef7ca6c49",
+      "comment": "First event created",
+      "command": "assertElementPresent",
+      "target": "css=.msg_ok",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "25390779-5987-483b-b498-096812147ae3",
+      "comment": "Capture idE of first event for cleanup",
+      "command": "executeScript",
+      "target": "return new URLSearchParams(window.location.search).get('idE');",
+      "targets": [],
+      "value": "firstEventId"
+    }, {
+      "id": "f07878bb-9c66-4917-94b5-611a2b2ea308",
+      "comment": "Try to add a near-duplicate",
+      "command": "open",
+      "target": "/evenement-edit.php?action=ajouter",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "57416fa6-64b6-4b92-8f76-bb727eac2720",
+      "comment": "",
+      "command": "click",
+      "target": "id=genre_divers",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "dbb702a2-f26a-4600-ad42-51e920d3e721",
+      "comment": "Title with extra 's' (Levenshtein 1)",
+      "command": "type",
+      "target": "id=titre",
+      "targets": [],
+      "value": "Selenium doublon detections"
+    }, {
+      "id": "4e62b899-b8b0-43dd-86e5-72d4d4e0dbff",
+      "comment": "",
+      "command": "type",
+      "target": "id=dateEvenement",
+      "targets": [],
+      "value": "${eventDate}"
+    }, {
+      "id": "bc71a27f-0d0a-4db7-b345-39b67c084f2f",
+      "comment": "",
+      "command": "type",
+      "target": "id=description",
+      "targets": [],
+      "value": "Tentative de creation d'un doublon."
+    }, {
+      "id": "54b563ce-8b1f-4d2a-9c3e-5316ca9681e9",
+      "comment": "",
+      "command": "type",
+      "target": "id=horaire_debut",
+      "targets": [],
+      "value": "20:30"
+    }, {
+      "id": "ee709369-f5ef-4174-a20a-c8bc0b6ce3da",
+      "comment": "",
+      "command": "type",
+      "target": "id=horaire_fin",
+      "targets": [],
+      "value": "22:30"
+    }, {
+      "id": "6eb07bc7-e56b-4177-822f-1572fff5481d",
+      "comment": "Same lieu",
+      "command": "select",
+      "target": "id=idLieu",
+      "targets": [],
+      "value": "label=Lieu Test Selenium"
+    }, {
+      "id": "02d74738-301b-49fb-a5de-4909617f2680",
+      "comment": "",
+      "command": "type",
+      "target": "id=prix",
+      "targets": [],
+      "value": "Libre"
+    }, {
+      "id": "4d5d89fe-f5eb-4451-9bd7-e1580fca6fba",
+      "comment": "",
+      "command": "click",
+      "target": "name=submit",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "25813c70-8319-47c7-8d42-a496703ae57d",
+      "comment": "",
+      "command": "pause",
+      "target": "2000",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "41ee0983-392b-43da-80d9-1117565f1f42",
+      "comment": "Duplicate warning is shown",
+      "command": "assertElementPresent",
+      "target": "css=.duplicate-warning",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "5d5a02e9-bcfa-4b16-ab42-0fff074f21d1",
+      "comment": "Confirm checkbox is present",
+      "command": "assertElementPresent",
+      "target": "css=input[name='confirm_duplicate']",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "f732e510-bcad-4dc6-b4f0-1762dcaa5ec6",
+      "comment": "Confirm submit button is present",
+      "command": "assertElementPresent",
+      "target": "css=.confirm-submit",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "96485ebd-8bfa-46f3-92cc-d60347af0dad",
+      "comment": "Tick confirm checkbox",
+      "command": "click",
+      "target": "name=confirm_duplicate",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "0b46882a-9d3b-4684-9bce-f3eb882e1ea6",
+      "comment": "Submit via the warning's Confirmer button",
+      "command": "click",
+      "target": "css=.confirm-submit",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "84483d44-628a-421d-85e1-13a0befc02a0",
+      "comment": "",
+      "command": "pause",
+      "target": "3000",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "6ff13b4c-bd29-4974-b664-3aa3e44357e2",
+      "comment": "Second event created after confirmation",
+      "command": "assertElementPresent",
+      "target": "css=.msg_ok",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "f03c76b8-c9b7-4bd0-9f1e-957c071592af",
+      "comment": "Capture idE of second event for cleanup",
+      "command": "executeScript",
+      "target": "return new URLSearchParams(window.location.search).get('idE');",
+      "targets": [],
+      "value": "secondEventId"
+    }, {
+      "id": "f83d4225-fdd5-4077-88f5-5aadb894b54d",
+      "comment": "Cleanup: delete first event",
+      "command": "open",
+      "target": "/event/actions.php?action=delete&id=${firstEventId}",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "1c27bb80-1725-4cca-9cd0-4d13f528761c",
+      "comment": "Cleanup: delete second event",
+      "command": "open",
+      "target": "/event/actions.php?action=delete&id=${secondEventId}",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "68da1cef-9251-4df4-b768-d68c51836a41",
+      "comment": "Return to home page",
+      "command": "open",
+      "target": "/",
+      "targets": [],
+      "value": ""
+    }]
   }],
   "suites": [{
     "id": "e598238f-e9bc-40f6-9876-6274e4bf1e3f",
@@ -7967,7 +8237,7 @@
     "persistSession": false,
     "parallel": false,
     "timeout": 300,
-    "tests": ["fa4a12b8-1f55-4435-8fe1-3fe8294be63a", "d5d4f0bd-52d5-4cd9-8fd2-b38ee992812d", "5c790b97-c4b1-4056-a004-daa889c1a3ee", "2422f54c-2560-4fa2-ad65-b10fe0deba9e", "1e32da4f-4dcb-4195-8dee-81a2afc12a3f", "b4c14c81-4533-4742-8d96-526b91077359", "1e0fa7b9-f784-4860-a139-b7be9b393fc0", "8f01a9a0-9f4c-4f52-825e-a54eba6fcb27", "92d58e15-7bbd-49aa-8440-5c14b4554622", "7f6cb209-b243-4a0e-889f-097dd12be52d", "9c8c7ca0-0ac3-496e-b84b-bfedbc01230b", "602346d1-62ed-43a5-9bfd-b78a52eaaa59", "816a221b-9428-4767-9d1b-cf51dc2f8fb4", "1b3cabfb-9a16-44ae-b21b-2356228e88f1", "a1b2c3d4-5678-90ab-cdef-lieu-salle-01", "0ae3b38b-98d6-4dfd-92c9-d26b5a4b768e", "7cbaa9a9-70bf-4812-af0a-7935df36f2a0"]
+    "tests": ["fa4a12b8-1f55-4435-8fe1-3fe8294be63a", "d5d4f0bd-52d5-4cd9-8fd2-b38ee992812d", "5c790b97-c4b1-4056-a004-daa889c1a3ee", "2422f54c-2560-4fa2-ad65-b10fe0deba9e", "1e32da4f-4dcb-4195-8dee-81a2afc12a3f", "b4c14c81-4533-4742-8d96-526b91077359", "de2e2d23-e992-4f76-a3c0-663b485ed1f9", "1e0fa7b9-f784-4860-a139-b7be9b393fc0", "8f01a9a0-9f4c-4f52-825e-a54eba6fcb27", "92d58e15-7bbd-49aa-8440-5c14b4554622", "7f6cb209-b243-4a0e-889f-097dd12be52d", "9c8c7ca0-0ac3-496e-b84b-bfedbc01230b", "602346d1-62ed-43a5-9bfd-b78a52eaaa59", "816a221b-9428-4767-9d1b-cf51dc2f8fb4", "1b3cabfb-9a16-44ae-b21b-2356228e88f1", "a1b2c3d4-5678-90ab-cdef-lieu-salle-01", "0ae3b38b-98d6-4dfd-92c9-d26b5a4b768e", "7cbaa9a9-70bf-4812-af0a-7935df36f2a0"]
   }],
   "urls": ["https://ladecadanse.darksite.ch/", "http://ladecadanse.local/", "https://ladecadanse.local/"],
   "plugins": []

--- a/tests/map.md
+++ b/tests/map.md
@@ -109,6 +109,9 @@ Evaluation of feature :
     - redir to event page
     - success msg
     - event displayed = changes
+    - duplicate detection on add (same date + same lieu + title within Levenshtein 5)
+        - warning block, list of similar events
+        - confirm checkbox + button to override
 
 - (u) delete (c2)
   - confirm js

--- a/web/css/formulaires.css
+++ b/web/css/formulaires.css
@@ -468,6 +468,16 @@ font-family:Georgia;
             color: #1b4f8a;
         }
 
+        #contenu .duplicate-warning .duplicate-list .duplicate-edit
+        {
+            margin-left: 0.4em;
+        }
+
+            #contenu .duplicate-warning .duplicate-list .duplicate-edit img
+            {
+                vertical-align: middle;
+            }
+
         #contenu .duplicate-warning .duplicate-list .horaire
         {
             color: #5b2a05;
@@ -495,6 +505,15 @@ font-family:Georgia;
     .duplicate-warning .confirm-submit
     {
         margin-left: auto;
+    }
+
+    form#ajouter_editer .submit:disabled
+    {
+        background-color: #ece4d7;
+        border-color: #b9a98f;
+        color: #9c8f78;
+        -webkit-text-fill-color: #9c8f78;
+        cursor: not-allowed;
     }
 
 form#ajouter_editer .duplicate-warning .confirm-label

--- a/web/css/formulaires.css
+++ b/web/css/formulaires.css
@@ -427,3 +427,92 @@ font-family:Georgia;
     border: 1px solid #aaa;
     color: #555;
 }
+
+.duplicate-warning
+{
+    background: #fff4e5;
+    border-left: 4px solid #d97706;
+    color: #5b2a05;
+    padding: 1em 1.2em;
+    margin: 0 0 1.2em 0;
+    border-radius: 2px;
+}
+
+    .duplicate-warning h2
+    {
+        color: #7c2d12;
+        margin: 0 0 0.6em 0;
+        font-size: 1.25em;
+    }
+
+    .duplicate-warning p
+    {
+        margin: 0.5em 0;
+        line-height: 1.4em;
+    }
+
+    #contenu .duplicate-warning .duplicate-list
+    {
+        margin: 0.4em 0 0.8em 0;
+        padding: 0;
+        list-style: none;
+    }
+
+        #contenu .duplicate-warning .duplicate-list li
+        {
+            margin: 0.35em 0;
+        }
+
+        #contenu .duplicate-warning .duplicate-list a
+        {
+            color: #1b4f8a;
+        }
+
+        #contenu .duplicate-warning .duplicate-list .horaire
+        {
+            color: #5b2a05;
+            margin-left: 0.4em;
+        }
+
+        #contenu .duplicate-warning .duplicate-list .statut
+        {
+            color: #856404;
+            margin-left: 0.4em;
+            text-transform: lowercase;
+        }
+
+    .duplicate-warning .confirm-row
+    {
+        margin: 1em 0 0 0;
+        padding-top: 0.8em;
+        border-top: 1px solid #f0c896;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 1em;
+    }
+
+    .duplicate-warning .confirm-submit
+    {
+        margin-left: auto;
+    }
+
+form#ajouter_editer .duplicate-warning .confirm-label
+{
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    width: auto;
+    text-align: left;
+    margin: 0;
+    padding: 0;
+    cursor: pointer;
+    font-weight: bold;
+    color: #5b2a05;
+}
+
+    form#ajouter_editer .duplicate-warning .confirm-label input[type="checkbox"]
+    {
+        width: auto;
+        margin: 0;
+    }

--- a/web/js/forms.js
+++ b/web/js/forms.js
@@ -30,3 +30,13 @@ $('input.datepicker_from').Zebra_DatePicker({...ZebraDatepickerBasicConfig, ...i
 const inputDatepickerToConfig = {direction: 1, readonly_element: false};
 $('input.datepicker_to').Zebra_DatePicker({...ZebraDatepickerBasicConfig, ...inputDatepickerToConfig});
 
+const confirmDuplicateCheckbox = document.querySelector('.duplicate-warning input[name="confirm_duplicate"]');
+if (confirmDuplicateCheckbox) {
+    const duplicateForm = confirmDuplicateCheckbox.closest('form');
+    const duplicateSubmits = duplicateForm.querySelectorAll('input[type="submit"], button[type="submit"]');
+    const syncDuplicateSubmits = () => {
+        duplicateSubmits.forEach(button => { button.disabled = !confirmDuplicateCheckbox.checked; });
+    };
+    syncDuplicateSubmits();
+    confirmDuplicateCheckbox.addEventListener('change', syncDuplicateSubmits);
+}


### PR DESCRIPTION
When submitting a new event whose title is within Levenshtein 5 of an existing event at the same lieu and date, the form re-renders with a warning listing similar events and a confirmation checkbox. The user can either click the existing event to edit it, or tick the checkbox and click "Confirmer" to proceed with creation.

Adds Evenement::normalizeTitre + Evenement::findSimilarEvenements helpers and a Selenium IDE e2e regression test (with cleanup).