### PR TITLE
fix(lieu,organisateur): default to last page for past events

### DIFF
--- a/lieu/lieu.php
+++ b/lieu/lieu.php
@@ -44,8 +44,22 @@ if (!empty($_GET['periode']) && Validateur::validateUrlQueryValue($_GET['periode
     }
 }
 
-$get['page'] = !empty($_GET['page']) ? Validateur::validateUrlQueryValue($_GET['page'], "int", 1) : 1;
 $results_per_page = 50;
+
+$sql_select_all =
+    "SELECT count(*) AS nb
+    FROM evenement e
+    WHERE
+    e.statut NOT IN ('inactif', 'propose') AND e.idLieu = ?";
+
+$sql_select_all .= " AND e.dateEvenement $sql_periode_operator ?";
+//echo $sql_select_all;
+$stmtAll = $connectorPdo->prepare($sql_select_all);
+$stmtAll->execute([$get['idL'], $glo_auj]);
+$all_results_nb = $stmtAll->fetchColumn();
+
+$default_page = $get['periode'] == "ancien" ? (int) max(1, ceil($all_results_nb / $results_per_page)) : 1;
+$get['page'] = !empty($_GET['page']) ? Validateur::validateUrlQueryValue($_GET['page'], "int", 1) : $default_page;
 
 $categories_fr = implode(", ", array_map(fn ($cat) : string => $glo_categories_lieux[$cat], explode(",", str_replace(" ", "", $lieu['categorie']))));
 $lieu_salles = Lieu::getActivesSalles((int) $get['idL']);
@@ -109,18 +123,6 @@ foreach ($page_results as $event) {
 }
 
 //dump($page_results_grouped_by_yearmonth);
-
-$sql_select_all =
-    "SELECT count(*) AS nb
-    FROM evenement e
-    WHERE
-    e.statut NOT IN ('inactif', 'propose') AND e.idLieu = ?";
-
-$sql_select_all .= " AND e.dateEvenement $sql_periode_operator ?";
-//echo $sql_select_all;
-$stmtAll = $connectorPdo->prepare($sql_select_all);
-$stmtAll->execute([$get['idL'], $glo_auj]);
-$all_results_nb = $stmtAll->fetchColumn();
 
 $page_titre = $lieu['nom']. " - ".HtmlShrink::adresseCompacteSelonContexte($lieu['loc_canton'], $lieu['loc_localite'], $lieu['quartier'], $lieu['adresse']);
 $page_description = $page_titre." : accès, horaires, description, photos et prochains événements";

--- a/organisateur/organisateur.php
+++ b/organisateur/organisateur.php
@@ -48,8 +48,21 @@ if (!empty($_GET['periode']) && Validateur::validateUrlQueryValue($_GET['periode
     }
 }
 
-$get['page'] = !empty($_GET['page']) ? Validateur::validateUrlQueryValue($_GET['page'], "int", 1) : 1;
 $results_per_page = 50;
+
+$sql_select_all =
+    "SELECT count(*) AS nb
+    FROM evenement e
+    JOIN evenement_organisateur eo ON e.idEvenement = eo.idEvenement
+    WHERE
+    e.statut NOT IN ('inactif', 'propose') AND eo.idOrganisateur = ? AND e.dateEvenement $sql_periode_operator ?";
+// echo $sql_select_all;
+$stmtAll = $connectorPdo->prepare($sql_select_all);
+$stmtAll->execute([$get['idO'], $glo_auj]);
+$all_results_nb = $stmtAll->fetchColumn();
+
+$default_page = $get['periode'] == "ancien" ? (int) max(1, ceil($all_results_nb / $results_per_page)) : 1;
+$get['page'] = !empty($_GET['page']) ? Validateur::validateUrlQueryValue($_GET['page'], "int", 1) : $default_page;
 
 $orga_lieux = Organisateur::getActivesLieux($get['idO']);
 $orga_personnes = Personne::getPersonnesOfOrganisateur($get['idO']);
@@ -115,17 +128,6 @@ foreach ($page_results as $event) {
 }
 
 //dump($page_results_grouped_by_yearmonth);
-
-$sql_select_all =
-    "SELECT count(*) AS nb
-    FROM evenement e
-    JOIN evenement_organisateur eo ON e.idEvenement = eo.idEvenement
-    WHERE
-    e.statut NOT IN ('inactif', 'propose') AND eo.idOrganisateur = ? AND e.dateEvenement $sql_periode_operator ?";
-// echo $sql_select_all;
-$stmtAll = $connectorPdo->prepare($sql_select_all);
-$stmtAll->execute([$get['idO'], $glo_auj]);
-$all_results_nb = $stmtAll->fetchColumn();
 
 $page_titre = $organisateur->getValue('nom');
 $page_description = $organisateur->getValue('nom') . " : informations pratiques, présentation et événements";


### PR DESCRIPTION
## Summary
- Sur les pages Lieu et Organisateur, dans l'onglet Événements, cliquer sur « Passés » ouvrait toujours la page 1 (les événements les plus anciens), puisque le tri reste ascendant par date.
- Le nombre total de résultats est maintenant calculé avant d'appliquer la pagination, ce qui permet de définir la page par défaut sur la dernière page (les événements passés les plus récents) quand periode=ancien et qu'aucune page n'est explicitement demandée dans l'URL.
- Le comportement de l'onglet « Prochains » (page 1 par défaut) est inchangé.

## Test plan
- [ ] Ouvrir une page Lieu ayant plusieurs pages d'événements passés, cliquer sur « Passés » : la dernière page (événements les plus récents) doit s'afficher par défaut.
- [ ] Idem sur une page Organisateur.
- [ ] Vérifier que naviguer explicitement via `?periode=ancien&page=1` affiche toujours bien la première page (comportement explicite non affecté).
- [ ] Vérifier que l'onglet « Prochains » affiche toujours la page 1 par défaut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)