### PR TITLE
feat(evenement): allow admin to notify event author of changes made

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -80,6 +80,15 @@ $glo_tab_genre = ["fête" => "fêtes", "cinéma" => "ciné", "théâtre" => "th�
 $statuts_evenement = ['propose' => 'Proposé', 'actif' => 'Proposé', 'complet' => 'Complet', 'annule' => 'Annulé', 'inactif' => 'Dépublié'];
 $price_types = ['unknown' => 'inconnu', 'gratis' => 'entrée libre', 'asyouwish' => 'prix libre', 'chargeable' => 'payant'];
 $tab_tri_agenda = ["dateAjout", "horaire_debut"];
+$glo_motifs_notification_auteur = [
+    'depublie_charte'     => "l'événement a été dépublié car il enfreint la charte éditoriale",
+    'depublie_doublon'    => "l'événement a été dépublié car il existe déjà dans l'agenda",
+    'categorie_deplacee'  => "l'événement a été déplacé dans une catégorie plus appropriée",
+    'erreurs_corrigees'   => "une ou plusieurs erreurs ont été corrigées",
+    'lieu_remplace'       => "le lieu écrit manuellement a été remplacé par le lieu équivalent enregistré sur La décadanse",
+    'organisateur_ajoute' => "un organisateur manquant a été ajouté",
+    'image_ajoutee'       => "une image de l'événement a été ajoutée ou changée",
+];
 
 //// PLACES
 $statuts_lieu = ['actif', 'ancien', 'inactif'];

--- a/evenement-edit.php
+++ b/evenement-edit.php
@@ -99,19 +99,21 @@ if ($get['action'] != "ajouter" && $get['action'] != "insert")
     }
 }
 
-// Résolution de l'auteur original de l'événement, pour le fieldset "Message à l'auteur" (issue #149)
+// Résolution de l'auteur original de l'événement, pour le fieldset "E-mail à l'auteur" (issue #149)
 // (ne pas utiliser $champs['idPersonne'] plus bas : il est écrasé par l'idPersonne de la session courante)
-$original_author_groupe = null; // null = soumission anonyme, traitée comme non-admin
-$original_author_email  = null;
-$original_author_name   = '';
+$original_author_groupe     = null; // null = soumission anonyme, traitée comme non-admin
+$original_author_email      = null;
+$original_author_name       = '';
+$original_author_idPersonne = null;
 if (!empty($tab_even_lieu['idPersonne']))
 {
     $auteur = Personne::getPersonneById((int) $tab_even_lieu['idPersonne']);
     if ($auteur)
     {
-        $original_author_groupe = (int) $auteur['groupe'];
-        $original_author_email  = $auteur['email'];
-        $original_author_name   = $auteur['pseudo'];
+        $original_author_groupe     = (int) $auteur['groupe'];
+        $original_author_email      = $auteur['email'];
+        $original_author_name       = $auteur['pseudo'];
+        $original_author_idPersonne = (int) $auteur['idPersonne'];
     }
 }
 elseif (!empty($tab_even_lieu['user_email']))
@@ -331,7 +333,7 @@ if (isset($_POST['formulaire']) && $_POST['formulaire'] === 'ok')
     $verif->valider($champs['prix'], "prix", "texte", 1, 100, 0);
 	$verif->valider($champs['prelocations'], "prelocations", "texte", 1, 200, 0);
 
-    // "Message à l'auteur" (issue #149) : ne pas mettre dans $champs, ce ne sont pas des colonnes de evenement
+    // "E-mail à l'auteur" (issue #149) : ne pas mettre dans $champs, ce ne sont pas des colonnes de evenement
     $notif_motifs = [];
     if ($can_notify_auteur && isset($_POST['notif_motifs']) && is_array($_POST['notif_motifs']))
     {
@@ -340,7 +342,8 @@ if (isset($_POST['formulaire']) && $_POST['formulaire'] === 'ok')
     $notif_message = $can_notify_auteur ? trim((string) ($_POST['notif_message'] ?? '')) : '';
     if ($can_notify_auteur)
     {
-        $verif->valider($notif_message, "notif_message", "texte", 0, 2000, 0);
+        // le message est obligatoire seulement si aucun motif n'a été sélectionné
+        $verif->valider($notif_message, "notif_message", "texte", 0, 2000, empty($notif_motifs) ? 1 : 0);
     }
 
     // public : email (required) and remark
@@ -703,7 +706,7 @@ if (isset($_POST['formulaire']) && $_POST['formulaire'] === 'ok')
                     }
                 }
 
-                // Message à l'auteur (issue #149)
+                // E-mail à l'auteur (issue #149)
                 if ($can_notify_auteur && (!empty($notif_motifs) || $notif_message !== ''))
                 {
                     $notifier = new AuteurNotifier($tplEngine, new Mailing());
@@ -713,6 +716,7 @@ if (isset($_POST['formulaire']) && $_POST['formulaire'] === 'ok')
                         $champs['titre'],
                         $champs['dateEvenement'],
                         $tab_even_lieu['dateAjout'] ?? '',
+                        $site_full_url . "event/evenement.php?idE=" . $req_id,
                         $_SESSION['Semail'] ?? EMAIL_ADMIN,
                         $_SESSION['user'] ?? '',
                         $notif_motifs,
@@ -1537,7 +1541,14 @@ else
 
 <?php if ($can_notify_auteur): ?>
 <fieldset>
-    <legend>Message à l’auteur</legend>
+    <legend>E-mail à l’auteur</legend>
+    <p>
+        <label>Pour</label>
+        <?php if (!empty($original_author_idPersonne)) { ?>
+        <a href="/user.php?idP=<?php echo $original_author_idPersonne ?>"><?php echo sanitizeForHtml($original_author_name) ?></a> —
+        <?php } ?>
+        <a href="mailto:<?php echo sanitizeForHtml($original_author_email) ?>"><?php echo sanitizeForHtml($original_author_email) ?></a>
+    </p>
     <p>
         <label for="notif_motifs">Motif(s)</label>
         <select name="notif_motifs[]" id="notif_motifs" multiple data-placeholder="Choisissez un ou plusieurs motifs (optionnel)">
@@ -1548,7 +1559,7 @@ else
         <?php echo $verif->getHtmlErreur('notif_motifs'); ?>
     </p>
     <p>
-        <label for="notif_message">Message</label>
+        <label for="notif_message">Message<?php echo empty($notif_motifs) ? ' *' : '' ?></label>
         <textarea name="notif_message" id="notif_message" cols="20" rows="6" maxlength="2000"><?php echo sanitizeForHtml($notif_message) ?></textarea>
         <?php echo $verif->getHtmlErreur('notif_message'); ?>
     </p>

--- a/evenement-edit.php
+++ b/evenement-edit.php
@@ -9,9 +9,11 @@ use Ladecadanse\Security\SecurityToken;
 use Ladecadanse\Evenement; // domain
 use Ladecadanse\EvenementRenderer; // presentation
 use Ladecadanse\Utils\Mailing;
+use Ladecadanse\Utils\AuteurNotifier;
 use Ladecadanse\HtmlShrink; // template
 use Ladecadanse\UserLevel; // domain
 use Ladecadanse\Utils\DateHelper;
+use Ladecadanse\Personne;
 
 // template...
 $page_titre = "Proposer un événement";
@@ -82,7 +84,7 @@ if (isset($_GET['idO']))
 // autorization to edit : author, 'admin' level, member of lieu, member of organisateur, member of lieu's organisateur
 if ($get['action'] != "ajouter" && $get['action'] != "insert")
 {
-    $res_even_lieu = $connector->query("SELECT idLieu, statut FROM evenement WHERE idEvenement=" . (int) $get['idE']);
+    $res_even_lieu = $connector->query("SELECT idLieu, statut, idPersonne, user_email, dateAjout FROM evenement WHERE idEvenement=" . (int) $get['idE']);
     $tab_even_lieu = $connector->fetchArray($res_even_lieu);
 
     if (
@@ -97,6 +99,32 @@ if ($get['action'] != "ajouter" && $get['action'] != "insert")
     }
 }
 
+// Résolution de l'auteur original de l'événement, pour le fieldset "Message à l'auteur" (issue #149)
+// (ne pas utiliser $champs['idPersonne'] plus bas : il est écrasé par l'idPersonne de la session courante)
+$original_author_groupe = null; // null = soumission anonyme, traitée comme non-admin
+$original_author_email  = null;
+$original_author_name   = '';
+if (!empty($tab_even_lieu['idPersonne']))
+{
+    $auteur = Personne::getPersonneById((int) $tab_even_lieu['idPersonne']);
+    if ($auteur)
+    {
+        $original_author_groupe = (int) $auteur['groupe'];
+        $original_author_email  = $auteur['email'];
+        $original_author_name   = $auteur['pseudo'];
+    }
+}
+elseif (!empty($tab_even_lieu['user_email']))
+{
+    $original_author_email = $tab_even_lieu['user_email'];
+}
+
+$can_notify_auteur =
+    isset($_SESSION['Sgroupe']) && $_SESSION['Sgroupe'] <= UserLevel::ADMIN
+    && ($get['action'] === "editer" || $get['action'] === "update") && isset($get['idE'])
+    && !empty($original_author_email)
+    && ($original_author_groupe === null || $original_author_groupe >= UserLevel::AUTHOR);
+
 // form values received
 $champs = ["statut" => "", "genre" => "", "titre" => "", "dateEvenement" => "", "idLieu" => 0,
  "idSalle" => 0, "nomLieu" => "", "adresse" => "", "quartier" => "",  "localite_id" => "", "region" => "", "urlLieu" => "", 'organisateurs' => '', "description" => "", "ref" => "",
@@ -107,6 +135,8 @@ $url_flyer = '';
 $url_image = '';
 $fetched_flyer = null;
 $fetched_image = null;
+$notif_motifs = [];
+$notif_message = '';
 
 $show_form = true;
 $formTokenName = 'form_token_evenement_edit';
@@ -300,6 +330,18 @@ if (isset($_POST['formulaire']) && $_POST['formulaire'] === 'ok')
 	$verif->valider($champs['horaire_complement'], "horaire_complement", "texte", 1, 200, 0);
     $verif->valider($champs['prix'], "prix", "texte", 1, 100, 0);
 	$verif->valider($champs['prelocations'], "prelocations", "texte", 1, 200, 0);
+
+    // "Message à l'auteur" (issue #149) : ne pas mettre dans $champs, ce ne sont pas des colonnes de evenement
+    $notif_motifs = [];
+    if ($can_notify_auteur && isset($_POST['notif_motifs']) && is_array($_POST['notif_motifs']))
+    {
+        $notif_motifs = array_values(array_intersect($_POST['notif_motifs'], array_keys($glo_motifs_notification_auteur)));
+    }
+    $notif_message = $can_notify_auteur ? trim((string) ($_POST['notif_message'] ?? '')) : '';
+    if ($can_notify_auteur)
+    {
+        $verif->valider($notif_message, "notif_message", "texte", 0, 2000, 0);
+    }
 
     // public : email (required) and remark
     if (!isset($_SESSION['Sgroupe']))
@@ -658,6 +700,28 @@ if (isset($_POST['formulaire']) && $_POST['formulaire'] === 'ok')
 
                         $mailer = new Mailing();
                         $mailer->toUser($champs['user_email'], $subject, $contenu_message);
+                    }
+                }
+
+                // Message à l'auteur (issue #149)
+                if ($can_notify_auteur && (!empty($notif_motifs) || $notif_message !== ''))
+                {
+                    $notifier = new AuteurNotifier($tplEngine, new Mailing());
+                    $sent = $notifier->notify(
+                        $original_author_email,
+                        $original_author_name,
+                        $champs['titre'],
+                        $champs['dateEvenement'],
+                        $tab_even_lieu['dateAjout'] ?? '',
+                        $_SESSION['Semail'] ?? EMAIL_ADMIN,
+                        $_SESSION['user'] ?? '',
+                        $notif_motifs,
+                        $notif_message,
+                        $glo_motifs_notification_auteur
+                    );
+                    if ($sent)
+                    {
+                        $confirmation_flash_msg .= " Un message a été envoyé à l'auteur de l'événement.";
                     }
                 }
 
@@ -1470,6 +1534,26 @@ else
 <?php
 }
 ?>
+
+<?php if ($can_notify_auteur): ?>
+<fieldset>
+    <legend>Message à l’auteur</legend>
+    <p>
+        <label for="notif_motifs">Motif(s)</label>
+        <select name="notif_motifs[]" id="notif_motifs" multiple data-placeholder="Choisissez un ou plusieurs motifs (optionnel)">
+            <?php foreach ($glo_motifs_notification_auteur as $key => $label) { ?>
+            <option value="<?php echo sanitizeForHtml($key) ?>" <?php echo in_array($key, $notif_motifs, true) ? 'selected="selected"' : '' ?>><?php echo sanitizeForHtml($label) ?></option>
+            <?php } ?>
+        </select>
+        <?php echo $verif->getHtmlErreur('notif_motifs'); ?>
+    </p>
+    <p>
+        <label for="notif_message">Message</label>
+        <textarea name="notif_message" id="notif_message" cols="20" rows="6" maxlength="2000"><?php echo sanitizeForHtml($notif_message) ?></textarea>
+        <?php echo $verif->getHtmlErreur('notif_message'); ?>
+    </p>
+</fieldset>
+<?php endif; ?>
 
 <p class="piedForm">
         <input type="hidden" name="formulaire" value="ok" />

--- a/librairies/Personne.php
+++ b/librairies/Personne.php
@@ -33,6 +33,17 @@ class Personne
     }
 
 
+    public static function getPersonneById(int $idPersonne): ?array
+    {
+        global $connectorPdo;
+
+        $stmt = $connectorPdo->prepare("SELECT idPersonne, pseudo, email, groupe FROM personne WHERE idPersonne = ?");
+        $stmt->execute([$idPersonne]);
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $result === false ? null : $result;
+    }
+
+
     public static function getPersonnes(array $filters, string $orderBy = 'dateAjout', string $orderDir = 'DESC', ?int $page = null, ?int $nbLignes = null): array
     {
         global $connectorPdo;

--- a/librairies/Utils/AuteurNotifier.php
+++ b/librairies/Utils/AuteurNotifier.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * @package ladecadanse
+ * @copyright  Copyright (c) 2007 - 2025 Michel Gaudry <michel@ladecadanse.ch>
+ * @license    AGPL License; see LICENSE file for details.
+ */
+
+namespace Ladecadanse\Utils;
+
+use Ladecadanse\TemplateEngine;
+
+/**
+ * Sends the "l'administrateur a modifié votre événement" notification to an
+ * event's author. Takes plain scalars (not an Evenement/session object) so it
+ * can be reused by other callers (quick-edit, bulk-edit) that resolve the
+ * target author differently.
+ *
+ * @author Michel Gaudry <michel@ladecadanse.ch>
+ */
+class AuteurNotifier
+{
+    public function __construct(
+        private readonly TemplateEngine $templateEngine,
+        private readonly Mailing $mailing,
+    ) {
+    }
+
+    /**
+     * @param string[]             $motifKeys      keys already whitelisted against $motifsCatalogue by the caller
+     * @param array<string,string> $motifsCatalogue key => French label, e.g. $glo_motifs_notification_auteur
+     */
+    public function notify(
+        string $authorEmail,
+        string $authorName,
+        string $eventTitre,
+        string $eventDateEvenement,
+        string $eventDateCreation,
+        string $adminEmail,
+        string $adminName,
+        array $motifKeys,
+        string $message,
+        array $motifsCatalogue
+    ): bool {
+        $motifLabels = array_values(array_intersect_key($motifsCatalogue, array_flip($motifKeys)));
+
+        $dateFr = DateHelper::isoToFr($eventDateEvenement, 'annee', true, false, false);
+        $subject = "La décadanse : votre événement \"{$eventTitre}\" du {$dateFr} a été modifié par l'administrateur";
+
+        $motifClause = empty($motifLabels) ? '.' : ' : ' . implode(', ', $motifLabels) . '.';
+
+        $body = $this->templateEngine->render('event-notify-auteur-mail-body', [
+            'date_creation' => DateHelper::isoToFr($eventDateCreation, 'annee', true, false, false),
+            'motif_clause'  => $motifClause,
+            'message'       => trim($message),
+        ]);
+
+        return $this->mailing->toUser($authorEmail, $subject, $body, ['email' => $adminEmail, 'name' => $adminName]);
+    }
+}

--- a/librairies/Utils/AuteurNotifier.php
+++ b/librairies/Utils/AuteurNotifier.php
@@ -36,6 +36,7 @@ class AuteurNotifier
         string $eventTitre,
         string $eventDateEvenement,
         string $eventDateCreation,
+        string $eventUrl,
         string $adminEmail,
         string $adminName,
         array $motifKeys,
@@ -45,14 +46,24 @@ class AuteurNotifier
         $motifLabels = array_values(array_intersect_key($motifsCatalogue, array_flip($motifKeys)));
 
         $dateFr = DateHelper::isoToFr($eventDateEvenement, 'annee', true, false, false);
-        $subject = "La décadanse : votre événement \"{$eventTitre}\" du {$dateFr} a été modifié par l'administrateur";
+        $subject = "La décadanse : votre événement \"{$eventTitre}\" du {$dateFr}";
 
-        $motifClause = empty($motifLabels) ? '.' : ' : ' . implode(', ', $motifLabels) . '.';
+        $corps = "Concernant l'événement \"{$eventTitre}\" {$eventUrl} que vous avez ajouté le "
+            . DateHelper::isoToFr($eventDateCreation, 'annee', true, false, false) . " :";
+
+        foreach ($motifLabels as $label)
+        {
+            $corps .= "\n - {$label}";
+        }
+
+        $message = trim($message);
+        if ($message !== '')
+        {
+            $corps .= "\n\n{$message}";
+        }
 
         $body = $this->templateEngine->render('event-notify-auteur-mail-body', [
-            'date_creation' => DateHelper::isoToFr($eventDateCreation, 'annee', true, false, false),
-            'motif_clause'  => $motifClause,
-            'message'       => trim($message),
+            'corps' => $corps,
         ]);
 
         return $this->mailing->toUser($authorEmail, $subject, $body, ['email' => $adminEmail, 'name' => $adminName]);

--- a/resources/event-notify-auteur-mail-body.txt
+++ b/resources/event-notify-auteur-mail-body.txt
@@ -1,8 +1,6 @@
 Bonjour,
 
-L'événement que vous avez ajouté le %date_creation% a été modifié par l'administrateur%motif_clause%
-
-%message%
+%corps%
 
 Meilleures salutations
 

--- a/resources/event-notify-auteur-mail-body.txt
+++ b/resources/event-notify-auteur-mail-body.txt
@@ -1,0 +1,9 @@
+Bonjour,
+
+L'événement que vous avez ajouté le %date_creation% a été modifié par l'administrateur%motif_clause%
+
+%message%
+
+Meilleures salutations
+
+La décadanse


### PR DESCRIPTION
## Summary
- Adds a "Message à l'auteur" fieldset at the end of the event edit form (`evenement-edit.php`), visible only when the current session is ADMIN/SUPERADMIN and the event's author is AUTHOR-level or below (or anonymous)
- Admin can select one or more pre-written Motifs (config-driven list in `app/config.php`) and/or write a free-text message
- On save, sends an email to the author (Reply-To = acting admin) via a new, reusable `Ladecadanse\Utils\AuteurNotifier` class, built to be callable later by the quick-edit (#131) and bulk-edit features mentioned in the issue without modification
- Adds `Personne::getPersonneById()` (no equivalent existed) to resolve the original author's email/level — needed because `$champs['idPersonne']` gets overwritten with the editing admin's id during the update flow, not the original author's

## Test plan
- [x] `composer phpstan` — no errors
- [x] `composer test:api` — 10/10 passing
- [x] `php -l` on all changed/new files
- [x] Manual browser verification (local dev env `make start` is currently broken per project notes — could not exercise the actual form/email end-to-end; please verify visually before merging)

Closes #149