### PR TITLE
fix: calendrier admin always-visible ne recouvre plus les champs suivants

### DIFF
--- a/evenement-edit.php
+++ b/evenement-edit.php
@@ -968,14 +968,19 @@ if ($verif->nbErreurs() > 0)
             // POC : calendrier "always visible" (Zebra_DatePicker) sous le champ date, réservé au niveau SUPERADMIN
             $poc_calendrier_toujours_visible = isset($_SESSION['Sgroupe']) && (int) $_SESSION['Sgroupe'] === UserLevel::SUPERADMIN;
             ?>
-            <div style="display: inline-block;">
-                <label for="dateEvenement">Date*</label><input type="text" name="dateEvenement" id="dateEvenement" size="9" value="<?php echo sanitizeForHtml($champs['dateEvenement']); ?>" class="datepicker<?php echo $poc_calendrier_toujours_visible ? ' datepicker-always-visible' : ''; ?>" placeholder="jj.mm.aaaa" required />
+            <div style="display: flex; align-items: flex-start; gap: 6px; flex-wrap: wrap;">
+                <label for="dateEvenement" style="white-space: nowrap;">Date*</label>
+                <div style="display: flex; flex-direction: column; align-items: flex-start;">
+                    <input type="text" name="dateEvenement" id="dateEvenement" size="9" value="<?php echo sanitizeForHtml($champs['dateEvenement']); ?>" class="datepicker<?php echo $poc_calendrier_toujours_visible ? ' datepicker-always-visible' : ''; ?>" placeholder="jj.mm.aaaa" required />
                     <?php
                     echo $verif->getHtmlErreur('dateEvenement');
                     if ($poc_calendrier_toujours_visible) {
-                    ?><div id="calendarDiv"></div>
+                    // le calendrier est positionné en absolu par la librairie ; on réserve sa hauteur ici
+                    // pour qu'il occupe sa place dans le flux au lieu de recouvrir les champs suivants
+                    ?><div id="calendarDiv" style="position: relative; height: 340px; margin-top: 6px;"></div>
                     <?php } ?>
                 </div>
+            </div>
 
 
 


### PR DESCRIPTION
## Résumé
Suite au retour utilisateur sur le POC du calendrier "always visible" (SUPERADMIN uniquement) dans `evenement-edit.php` : le calendrier flottait par-dessus les champs suivants (Lieu, Localité, etc.) au lieu de prendre sa place dans la mise en page.

## Cause
La librairie Zebra_Datepicker positionne toujours le calendrier en `position: absolute` (même en mode `always_visible`), donc il ne pousse pas naturellement le contenu suivant vers le bas.

## Correctif
- `#calendarDiv` passe en `position: relative` avec une hauteur réservée (~340px, en tenant compte de la marge pour les liens "Aujourd'hui"/"Effacer"), pour que le calendrier occupe réellement sa place dans le flux au lieu de survoler le contenu suivant.
- Le champ date et le calendrier sont désormais dans une colonne flex dédiée (label à côté, dans une ligne flex séparée), afin que le côté gauche du calendrier coïncide avec le côté gauche du champ input date (et non celui du label), comme demandé.

## Test plan
- [ ] Connecté en SUPERADMIN, ouvrir `evenement-edit.php?action=ajouter` ou `?action=editer&idE=...` : le calendrier doit s'afficher sous le champ date, aligné à gauche avec celui-ci, et pousser les champs suivants (Lieu, etc.) vers le bas sans les recouvrir.
- [ ] Vérifier sur un mois nécessitant 6 lignes de semaines qu'il n'y a pas de léger recouvrement.
- [ ] Les autres niveaux d'utilisateur (ADMIN, AUTHOR, ACTOR, public) : comportement inchangé (popup au clic).

Branche de base : `worktree-poc-zebra-datepicker` (déjà mergée dans master, cf. commit 1e6fdfc), donc cette PR ne contient que le correctif de layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)