### PR TITLE
fix: espace résiduel sous le calendrier admin always-visible

### DIFF
--- a/evenement-edit.php
+++ b/evenement-edit.php
@@ -1043,9 +1043,10 @@ if ($verif->nbErreurs() > 0)
                     <?php
                     echo $verif->getHtmlErreur('dateEvenement');
                     if ($poc_calendrier_toujours_visible) {
-                    // le calendrier est positionné en absolu par la librairie ; on réserve sa hauteur ici
-                    // pour qu'il occupe sa place dans le flux au lieu de recouvrir les champs suivants
-                    ?><div id="calendarDiv" style="position: relative; height: 340px; margin-top: 6px;"></div>
+                    // le calendrier est positionné en absolu par la librairie ; on réserve sa place dans le flux
+                    // (au lieu de recouvrir les champs suivants) via position:relative, la hauteur exacte étant
+                    // ajustée dynamiquement en JS (forms.js) selon le nombre de semaines du mois et la largeur d'écran
+                    ?><div id="calendarDiv" style="position: relative; margin-top: 6px;"></div>
                     <?php } ?>
                 </div>
             </div>

--- a/web/js/forms.js
+++ b/web/js/forms.js
@@ -29,6 +29,19 @@ $('input.datepicker:not(.datepicker-always-visible)').Zebra_DatePicker({...Zebra
 if ($('input.datepicker-always-visible').length && $('#calendarDiv').length) {
     const inputDatepickerAlwaysVisibleConfig = {direction: [eventEditStartDate, false], always_visible: $('#calendarDiv')};
     $('input.datepicker-always-visible').Zebra_DatePicker({...ZebraDatepickerBasicConfig, ...inputDatepickerAlwaysVisibleConfig});
+
+    // le calendrier de la librairie est en position:absolute ; on ajuste dynamiquement la hauteur
+    // du conteneur (position:relative) sur celle réellement rendue, pour éviter tout espace vide
+    // résiduel (le nombre de semaines affichées varie selon le mois, et la largeur/le retour à la
+    // ligne du pied de page varient entre desktop et mobile)
+    const calendarDiv = document.getElementById('calendarDiv');
+    const syncCalendarHeight = () => {
+        const calendar = calendarDiv.querySelector('.Zebra_DatePicker');
+        calendarDiv.style.height = calendar ? calendar.offsetHeight + 'px' : '';
+    };
+    new MutationObserver(syncCalendarHeight).observe(calendarDiv, {childList: true, subtree: true});
+    window.addEventListener('resize', syncCalendarHeight);
+    syncCalendarHeight();
 }
 
 const inputDatepickerFromConfig = {direction: [eventEditStartDate, false], pair: $('input.datepicker_to'), readonly_element: false};


### PR DESCRIPTION
## Résumé
Suite au retour sur #190 : il restait un espace vide entre le bas du calendrier "always visible" (POC, réservé SUPERADMIN) et le champ suivant (Début/Fin).

## Cause
La hauteur du conteneur `#calendarDiv` (nécessaire en `position:relative` pour que le calendrier, toujours en `position:absolute` côté librairie, occupe sa place dans le flux) était fixée en dur à `340px`. Or la hauteur réelle du calendrier varie :
- selon le mois affiché (5 ou 6 lignes de semaines),
- selon la largeur d'écran (retour à la ligne du pied de page "Aujourd'hui"/"Effacer" sur mobile).

## Fix
- Suppression de la hauteur fixe en CSS/PHP (`evenement-edit.php`), le conteneur garde `position: relative`.
- `web/js/forms.js` : la hauteur du conteneur est désormais mesurée dynamiquement sur l'élément `.Zebra_DatePicker` réellement rendu, et resynchronisée :
  - à l'initialisation,
  - à chaque changement du calendrier (navigation mois, sélection, effacement) via un `MutationObserver`,
  - au redimensionnement de la fenêtre (desktop ↔ mobile).

## Test plan
- [ ] En tant que SUPERADMIN sur `evenement-edit.php` : plus d'espace vide entre le calendrier et le champ Début/Fin
- [ ] Naviguer entre un mois à 5 lignes et un mois à 6 lignes : pas d'espace résiduel ni de recouvrement dans les deux cas
- [ ] Tester en largeur mobile (réduire la fenêtre / DevTools responsive) : pas de recouvrement si le pied de page passe sur 2 lignes
- [ ] Vérifier que le comportement des autres niveaux utilisateurs (popup classique) est inchangé

Base : master (inclut déjà #190).