### PR TITLE
fix(seo): shorten the agenda title and meta description (#224)

### DIFF
--- a/_header.inc.php
+++ b/_header.inc.php
@@ -7,6 +7,8 @@ use Ladecadanse\UserLevel;
 // de sécurité, le verrou est purement au rendu : sans le script d'amorçage ci-dessous,
 // mouseless.js ne s'active jamais.
 $mouseless_allowed = isset($_SESSION['Sgroupe']) && (int) $_SESSION['Sgroupe'] <= UserLevel::ADMIN;
+
+$page_titre_complet = sanitizeForHtml($page_titre) . " — La décadanse";
 ?>
 
 <!doctype html>
@@ -25,7 +27,7 @@ $mouseless_allowed = isset($_SESSION['Sgroupe']) && (int) $_SESSION['Sgroupe'] <
         <meta name="robots" content="noindex, nofollow">
     <?php endif; ?>
 
-	<title><?= (ENV !== 'prod') ? '['.ENV.'] ' : '' ?><?= ($nom_page == 'index' && !isset($_GET['courant']) ? "La décadanse — " : "") . sanitizeForHtml($page_titre) . (!($nom_page === 'index' && isset($_GET['courant'])) ? " — La décadanse" : ""); ?></title>
+	<title><?= (ENV !== 'prod') ? '['.ENV.'] ' : '' ?><?= $page_titre_complet ?></title>
 
     <meta name="description" content="<?= sanitizeForHtml(($page_description ?? '')) ?>">
 
@@ -33,7 +35,7 @@ $mouseless_allowed = isset($_SESSION['Sgroupe']) && (int) $_SESSION['Sgroupe'] <
     <meta property="og:logo" content="/web/interface/apple-icon-152x152.png">
     <meta property="og:type" content="article">
     <meta property="og:locale" content="fr">
-    <meta property="og:title" content="<?= sanitizeForHtml($page_titre) . " — La décadanse"; ?>">
+    <meta property="og:title" content="<?= $page_titre_complet ?>">
     <meta property="og:description" content="<?= sanitizeForHtml(($page_description ?? '')) ?>">
     <?php if (isset($page_url)) : ?>
         <meta property="og:url" content="<?= $site_full_url . $page_url; ?>">

--- a/index.php
+++ b/index.php
@@ -18,16 +18,17 @@ use Ladecadanse\Utils\DateHelper;
 use Ladecadanse\Utils\Text;
 
 // used for meta tags, opengraph
-$page_titre = " agenda de sorties à Genève, Nyon, Lausanne, Pays de Gex, Annemasse...; prochains événements : concerts, soirées, films, théâtre, expos, bars, cinémas";
-$page_description = "Programme des prochains événements festifs et culturels à Genève, Nyon, Lausanne, Pays de Gex, Annemasse... : fêtes, concerts et soirées, cinéma, théâtre, expositions, vernissages, conférences, lieux culturels et alternatifs";
+$page_titre = "Agenda des sorties à Genève, Nyon et Lausanne";
+$page_description = "Agenda des sorties à Genève, Nyon, Lausanne et alentours : concerts, soirées, expos, théâtre, cinéma. Le programme du jour et des jours à venir.";
 
 // filter & overwrite date
 $get['courant'] = $glo_auj_6h;
 if (!empty($_GET['courant']) && preg_match("/^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$/", trim((string) $_GET['courant'])))
 {
     $get['courant'] = $_GET['courant'];
-    $page_titre = "Agenda d'événements du " . DateHelper::isoToFr($get['courant'], 'annee', html: false) . " à Genève, Nyon, Lausanne, Pays de Gex, Annemasse...";
-    $page_description = "Événements culturels et festifs du " . DateHelper::isoToFr($get['courant'], 'annee', html: false). " à Genève, Nyon, Lausanne, Pays de Gex, Annemasse... : concerts, soirées, films, théâtre, expos... ";
+    $date_fr = DateHelper::isoToFr($get['courant'], 'annee', html: false);
+    $page_titre = "Sorties du " . $date_fr . " à Genève";
+    $page_description = "Le programme du " . $date_fr . " à Genève, Nyon, Lausanne et alentours : concerts, soirées, expos, théâtre, cinéma.";
 }
 
 $is_courant_today = (empty($get['courant']) || $get['courant'] == $glo_auj_6h);


### PR DESCRIPTION
Closes #224.

## The defect

Google did not show the homepage meta description and built its own snippet out of an aquatic show listed on the page. The description ran to 224 characters, in three chained keyword lists, where Google displays around 155. The `<title>` had the same defect: 180 characters, with "La décadanse" repeated at both ends.

## The changes

**`index.php`** : title and description become one readable sentence, on the homepage and on the dated listings (`?courant=`) alike. The call to `DateHelper::isoToFr()`, made twice in a row, goes through a variable.

**`_header.inc.php`** : the brand appears once. The old expression put `La décadanse — ` in front **and** ` — La décadanse` behind on the homepage, hence the 180 characters; its two conditions being complementary, it put **nothing at all** on the dated listings. The title becomes uniformly `<page_titre> — La décadanse`, factored into `$page_titre_complet`, which `og:title` reuses, where the expression was duplicated.

## Rendered output, measured

| page | robots | title | description |
|---|---|---|---|
| `/` | - | 60 | 144 |
| `?courant=2026-09-11` | - | 61 | 125 |
| `?courant=2020-01-05` (past) | noindex | 58 | 122 |
| `/articles/apropos.php` | - | 31 | 79 |

Lengths taken from the served HTML, excluding the `[dev]` prefix, which only the dev environment adds to `<title>`. In production `og:title` is identical to `<title>` on all four; the past-day `noindex` still fires.

The worst case for the dated titles was swept over 2026 to 2032: `Sorties du mercredi 1er septembre 2027 à Genève — La décadanse`, **62 characters**. Naming Genève alone is the only wording that stays close to the ~60 character limit once the brand is appended; keeping `Nyon et Lausanne` reaches 79, dropping the weekday 71, `et alentours` 74, and it is the brand at the end of the string that Google would truncate. Nyon and Lausanne stay in the meta description of those same pages.

Deliberate trade to flag: "Pays de Gex" and "Annemasse" appeared only in the two rewritten lines and now appear in no title or description on the site. They are folded into "et alentours". Both are cross-border, low-volume for this agenda, and the words that carry these pages are the date and Genève.

## Tests

`composer test:site`: 109 tests, 851 assertions, 2 failures. `BotMonitoringCest::honeypotLinkIsInFooter` and `EvenementEditFormulaireCest::chaqueSalleEstProposeeUneSeuleFois` fail identically on a clean tree; they depend on local data. PHPStan and `php -l` pass on both files.

## Verification after deploy

```
curl -s https://www.ladecadanse.ch/ | grep 'name="description"'
```

then URL inspection in Search Console with a re-indexing request. The result in the SERP can take several days and remains at Google's discretion.

## Out of scope, spotted along the way

`lieu/lieux.php` has exactly the same defect: a 129 character keyword-list title, and no meta description at all. Same on `organisateur/organisateurs.php`. A natural follow-up, not handled here.
